### PR TITLE
Reformat API url structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ docker run -d --name=nerium_svc \
 -v /local/path/to/query_files:/app/query_files \
 -p 8081:8081 nerium
 
-$ curl http://localhost:8081/v1/<report_name>?<params>
+$ curl http://localhost:8081/v1/<query_name>?<params>
 ```
 
 ## Configuration
@@ -35,15 +35,11 @@ $ curl http://localhost:8081/v1/<report_name>?<params>
 
 ### URLs
 
-`/v1/<string:report_name>/?<params>`  
-`/v1/<string:query_extension>/<string:report_name>/?<params>`  
-`/v1/sql/<string:report_name>/<string:format>/?<params>`  
-`/v1/sql/<string:report_name>/compact/?<params>`
+`/v1/<string:query_name>/?[ne_format=<formatter>]&<query_params>`
 
-`report_name` should match the name of a given query script file, minus the file extension. Params are as specified in the queries themselves.
+`query_name` should match the name of a given query script file, minus the file extension. Params are as specified in the queries themselves.
 
-`query_extension` is an optional file extension string and defaults to 'sql'
-`format` is an optional formatter name, and defaults to 'default'. 'compact' is also available, as noted above. (Note that while optional, if you wish to specify a format, you must include the query_extension also.)
+`ne_format` may be passed as in the query string as an optional formatter name, and defaults to 'default'. Other supported `contrib` options are described in Content section below.
 
 Unknown values passed to `query_extension` or `format` will silently fall back to defaults.
 

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import decimal
 
 from flask import Flask, request
 from flask.json import JSONEncoder
-from flask_restful import Api, Resource, reqparse
+from flask_restful import Api, Resource
 from nerium.contrib.formatter import (AffixFormatter, CompactFormatter,
                                       CsvFormatter)
 from nerium.contrib.resultset import SQLResultSet
@@ -83,7 +83,6 @@ class ReportAPI(Resource):
             # TODO: add logging and log a warning here
             #     and/or return format not found message to client(?)
             payload = query_result
-        # else:
         return payload
 
 

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import decimal
 
 from flask import Flask, request
 from flask.json import JSONEncoder
-from flask_restful import Api, Resource
+from flask_restful import Api, Resource, reqparse
 from nerium.contrib.formatter import (AffixFormatter, CompactFormatter,
                                       CsvFormatter)
 from nerium.contrib.resultset import SQLResultSet
@@ -40,8 +40,8 @@ class BaseRoute(Resource):
 class ReportAPI(Resource):
     """ Calls ResultSet.result() and returns JSON
 
-        Given a report_name, query_extension, and format_ (via URL routes),
-        this Flask-RESTful Resource submits the query matching the report_name
+        Given a query_name, query_extension, and format_ (via URL routes),
+        this Flask-RESTful Resource submits the query matching the query_name
         to the appropriate query_extension subclass and optionally format
         results via the matching format_cls and let Resource do its JSON thing
     """
@@ -58,7 +58,7 @@ class ReportAPI(Resource):
         'csv': CsvFormatter,
     }
 
-    def get(self, report_name, query_extension='sql', format_='default'):
+    def get(self, query_name, query_extension='sql', format_='default'):
         # Lookup query_extension and fetch result from corresponding class
         # TODO: Consider adding this to query subdirectory dotenv
         #      (or something) - With backend_lookup and unique report names,
@@ -68,8 +68,12 @@ class ReportAPI(Resource):
         except KeyError:
             result_cls = SQLResultSet
 
-        loader = result_cls(report_name, **request.args.to_dict())
+        loader = result_cls(query_name, **request.args.to_dict())
         query_result = loader.result_set()
+
+        ne_format = request.args.get("ne_format")
+        if ne_format:
+            format_ = ne_format
 
         if format_ in self.format_lookup.keys():
             format_cls = self.format_lookup[format_]
@@ -79,14 +83,13 @@ class ReportAPI(Resource):
             # TODO: add logging and log a warning here
             #     and/or return format not found message to client(?)
             payload = query_result
+        # else:
         return payload
 
 
 api.add_resource(
     ReportAPI,
-    '/v1/<string:report_name>/',
-    '/v1/<string:query_extension>/<string:report_name>/',
-    '/v1/<string:query_extension>/<string:report_name>/<string:format_>/',
+    '/v1/<string:query_name>/',
     strict_slashes=False)
 
 api.add_resource(BaseRoute, '/', '/v1/', strict_slashes=False)

--- a/nerium/contrib/resultset/sql.py
+++ b/nerium/contrib/resultset/sql.py
@@ -7,7 +7,7 @@ from nerium import ResultSet
 
 class SQLResultSet(ResultSet):
     """ SQL database query implementation of ResultSet, using Records library
-    to fetch a dataset from configured report_name
+    to fetch a dataset from configured query_name
     """
 
     def backend_lookup(self, backend_path):

--- a/nerium/main.py
+++ b/nerium/main.py
@@ -23,15 +23,15 @@ class ResultSet(ABC):
 
 
     Args:
-        report_name (str): Name of chosen query file, without the extension
+        query_name (str): Name of chosen query file, without the extension
         kwargs: Parameter keys and values to bind to query
 
     Usage:
         Subclass and provide a 'result' method
     """
 
-    def __init__(self, report_name, **kwargs):
-        self.report_name = report_name
+    def __init__(self, query_name, **kwargs):
+        self.query_name = query_name
         self.kwargs = kwargs
 
     def get_query_path(self):
@@ -40,7 +40,7 @@ class ResultSet(ABC):
         files = [i for i in flat_directory if i.is_file()]
         try:
             query_path = next(
-                i for i in sorted(files) if i.stem == self.report_name)
+                i for i in sorted(files) if i.stem == self.query_name)
             return query_path
         except StopIteration:
             return None
@@ -53,7 +53,7 @@ class ResultSet(ABC):
             return [
                 {
                     'error': "No query found matching {}".format(
-                        self.report_name)
+                        self.query_name)
                 },
             ]
         else:
@@ -73,7 +73,7 @@ class ResultFormatter(ABC):
 
     def formatted_results(self):
         if 'error' in self.result[0].keys():
-            return self.result
+            return self.result, 400
         else:
             return self.format_results()
 

--- a/tests.py
+++ b/tests.py
@@ -39,14 +39,14 @@ TEST_SQL = """select cast(1.25 as float) as foo  -- float check
 
 def setUpModule():
     global sql_file
-    global report_name
+    global query_name
     with NamedTemporaryFile(
             dir='query_files', suffix='.sql', mode='w',
             delete=False) as _sql_file:
         sql_file = _sql_file
         sql_file.write(TEST_SQL)
         _report_name = os.path.basename(sql_file.name)
-        report_name = os.path.splitext(_report_name)[0]
+        query_name = os.path.splitext(_report_name)[0]
 
 
 def tearDownModule():
@@ -55,7 +55,7 @@ def tearDownModule():
 
 class TestSQLResultSet(unittest.TestCase):
     def test_results_expected(self):
-        loader = nerium.contrib.resultset.sql.SQLResultSet(report_name)
+        loader = nerium.contrib.resultset.sql.SQLResultSet(query_name)
         result = loader.result_set()
         self.assertEqual(result, EXPECTED)
 
@@ -65,11 +65,11 @@ class TestSQLAPI(unittest.TestCase):
         self.app = app.app.test_client()
 
     def test_response(self):
-        endpoint = '/v1/sql/{}/'.format(report_name)
+        endpoint = '/v1/sql/{}/'.format(query_name)
         response = self.app.get(endpoint)  # noqa F841
 
     def test_response_expected(self):
-        endpoint = '/v1/sql/{}/'.format(report_name)
+        endpoint = '/v1/sql/{}/'.format(query_name)
         response = self.app.get(endpoint)
         self.assertEqual(EXPECTED, json.loads(response.get_data()))
 


### PR DESCRIPTION
- lose the query_extension path, and
- move format specification to `ne_format` query string parameter
- add 400 to error message result in formatter base class