### PR TITLE
[WIP] return csv response

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,11 @@ class BaseRoute(Resource):
         return {"status": "ok"}
 
 
+@api.representation("text/csv")
+def output_csv(data, code, headers=None):
+    resp = app.make_response((data, code, headers))
+    return resp 
+
 # LIL FLASK APP
 class ReportAPI(Resource):
     """ Calls ResultSet.result() and returns JSON


### PR DESCRIPTION
Allows Accept to be set in the header for text/csv in order to get the data returned as an unprocessed csv string.
`http nerium/v1/fooquery?ne_format=csv Accept:text/csv`
```HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 11
Content-Type: text/csv
Date: Thu, 15 Mar 2018 21:35:53 GMT
Server: gunicorn/19.7.1

foo
1.25
```