### PR TITLE
Refactor plugin lookups to library

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,17 +1,12 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [dev-packages]
-
 isort = "*"
 
-
 [packages]
-
 Flask = "*"
 Flask-RESTful = "*"
 records = "*"
@@ -19,7 +14,5 @@ python-dotenv = "*"
 gunicorn = "*"
 "e1839a8" = {path = ".", editable = true}
 
-
 [requires]
-
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "886b6084ccf0a666c147cb9dfeb747ebea0265538b1e9a7d7c2c93e7d7084581"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "3.6.4",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "17.4.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64",
-            "python_full_version": "3.6.4",
-            "python_version": "3.6",
-            "sys_platform": "darwin"
-        },
         "pipfile-spec": 6,
         "requires": {
             "python_version": "3.6"
@@ -31,8 +18,8 @@
     "default": {
         "aniso8601": {
             "hashes": [
-                "sha256:f7052eb342bf2000c6264a253acedb362513bf9270800be2bc8e3e229fe08b5a",
-                "sha256:7cf068e7aec00edeb21879c2bbda048656c34d281e133a77425be03b352122d8"
+                "sha256:7cf068e7aec00edeb21879c2bbda048656c34d281e133a77425be03b352122d8",
+                "sha256:f7052eb342bf2000c6264a253acedb362513bf9270800be2bc8e3e229fe08b5a"
             ],
             "version": "==3.0.0"
         },
@@ -64,13 +51,15 @@
                 "sha256:0749df235e3ff61ac108f69ac178c9770caeaccad2509cb762ce1f65570a8856",
                 "sha256:49f44461237b69ecd901cc7ce66feea0319b9158743dd27a2899962ab214dac1"
             ],
+            "index": "pypi",
             "version": "==0.12.2"
         },
         "flask-restful": {
             "hashes": [
-                "sha256:e2f1b8063de3944b94c7f8be5cee4d2161db0267c54c5b757d875295061776fa",
-                "sha256:5795519501347e108c436b693ff9a4d7b373a3ac9069627d64e4001c05dd3407"
+                "sha256:5795519501347e108c436b693ff9a4d7b373a3ac9069627d64e4001c05dd3407",
+                "sha256:e2f1b8063de3944b94c7f8be5cee4d2161db0267c54c5b757d875295061776fa"
             ],
+            "index": "pypi",
             "version": "==0.3.6"
         },
         "gunicorn": {
@@ -78,6 +67,7 @@
                 "sha256:75af03c99389535f218cc596c7de74df4763803f7b63eb09d77e92b3956b36c6",
                 "sha256:eee1169f0ca667be05db3351a0960765620dad53f53434262ff8901b68a1b622"
             ],
+            "index": "pypi",
             "version": "==19.7.1"
         },
         "itsdangerous": {
@@ -107,8 +97,8 @@
         },
         "odfpy": {
             "hashes": [
-                "sha256:ab1d67311b3c42dfad1063692c419c137fd6d5a6f0c6380d13758c2593a2b8c9",
-                "sha256:6bcaf3b23aa9e49ed8c8c177266539b211add4e02402748a994451482a10cb1b"
+                "sha256:6bcaf3b23aa9e49ed8c8c177266539b211add4e02402748a994451482a10cb1b",
+                "sha256:ab1d67311b3c42dfad1063692c419c137fd6d5a6f0c6380d13758c2593a2b8c9"
             ],
             "version": "==1.3.6"
         },
@@ -123,60 +113,62 @@
                 "sha256:4965ed170bf51c347a89820e8050655e9c25db3837db6602e906b6d850fad85c",
                 "sha256:509736185257111613009974e666568a1b031b028b61b500ef1ab4ee780089d5"
             ],
+            "index": "pypi",
             "version": "==0.8.2"
         },
         "pytz": {
             "hashes": [
-                "sha256:ed6509d9af298b7995d69a440e2822288f2eca1681b8cce37673dbb10091e5fe",
-                "sha256:f93ddcdd6342f94cea379c73cddb5724e0d6d0a1c91c9bdef364dc0368ba4fda",
-                "sha256:61242a9abc626379574a166dc0e96a66cd7c3b27fc10868003fa210be4bff1c9",
-                "sha256:ba18e6a243b3625513d85239b3e49055a2f0318466e0b8a92b8fb8ca7ccdf55f",
                 "sha256:07edfc3d4d2705a20a6e99d97f0c4b61c800b8232dc1c04d87e8554f130148dd",
                 "sha256:3a47ff71597f821cd84a162e71593004286e5be07a340fd462f0d33a760782b5",
+                "sha256:410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0",
                 "sha256:5bd55c744e6feaa4d599a6cbd8228b4f8f9ba96de2c38d56f08e534b3c9edf0d",
+                "sha256:61242a9abc626379574a166dc0e96a66cd7c3b27fc10868003fa210be4bff1c9",
                 "sha256:887ab5e5b32e4d0c86efddd3d055c1f363cbaa583beb8da5e22d2fa2f64d51ef",
-                "sha256:410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0"
+                "sha256:ba18e6a243b3625513d85239b3e49055a2f0318466e0b8a92b8fb8ca7ccdf55f",
+                "sha256:ed6509d9af298b7995d69a440e2822288f2eca1681b8cce37673dbb10091e5fe",
+                "sha256:f93ddcdd6342f94cea379c73cddb5724e0d6d0a1c91c9bdef364dc0368ba4fda"
             ],
             "version": "==2018.3"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:3262c96a1ca437e7e4763e2843746588a965426550f3797a79fca9c6199c431f",
+                "sha256:0c507b7f74b3d2dd4d1322ec8a94794927305ab4cebbe89cc47fe5e81541e6e8",
                 "sha256:16b20e970597e051997d90dc2cddc713a2876c47e3d92d59ee198700c5427736",
-                "sha256:e863072cdf4c72eebf179342c94e6989c67185842d9997960b3e69290b2fa269",
+                "sha256:3262c96a1ca437e7e4763e2843746588a965426550f3797a79fca9c6199c431f",
+                "sha256:326420cbb492172dec84b0f65c80942de6cedb5233c413dd824483989c000608",
+                "sha256:4474f8ea030b5127225b8894d626bb66c01cda098d47a2b0d3429b6700af9fd8",
+                "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
+                "sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7",
+                "sha256:5f84523c076ad14ff5e6c037fe1c89a7f73a3e04cf0377cb4d017014976433f3",
+                "sha256:827dc04b8fa7d07c44de11fabbc888e627fa8293b695e0f99cb544fdfa1bf0d1",
+                "sha256:b4c423ab23291d3945ac61346feeb9a0dc4184999ede5e7c43e1ffb975130ae6",
                 "sha256:bc6bced57f826ca7cb5125a10b23fd0f2fff3b7c4701d64c439a300ce665fff8",
                 "sha256:c01b880ec30b5a6e6aa67b09a2fe3fb30473008c85cd6a67359a1b15ed6d83a4",
-                "sha256:827dc04b8fa7d07c44de11fabbc888e627fa8293b695e0f99cb544fdfa1bf0d1",
-                "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
-                "sha256:5f84523c076ad14ff5e6c037fe1c89a7f73a3e04cf0377cb4d017014976433f3",
-                "sha256:0c507b7f74b3d2dd4d1322ec8a94794927305ab4cebbe89cc47fe5e81541e6e8",
-                "sha256:b4c423ab23291d3945ac61346feeb9a0dc4184999ede5e7c43e1ffb975130ae6",
                 "sha256:ca233c64c6e40eaa6c66ef97058cdc80e8d0157a443655baa1b2966e812807ca",
-                "sha256:4474f8ea030b5127225b8894d626bb66c01cda098d47a2b0d3429b6700af9fd8",
-                "sha256:326420cbb492172dec84b0f65c80942de6cedb5233c413dd824483989c000608",
-                "sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7"
+                "sha256:e863072cdf4c72eebf179342c94e6989c67185842d9997960b3e69290b2fa269"
             ],
             "version": "==3.12"
         },
         "records": {
             "hashes": [
-                "sha256:6d060a2b44ecc198d4e86efd5dab8558a2581b4019970bd8839e1604a243f57e",
-                "sha256:238cba35e8efbb724493bbb195bd027d9e78db4a978597969a7af0f722ac3686"
+                "sha256:238cba35e8efbb724493bbb195bd027d9e78db4a978597969a7af0f722ac3686",
+                "sha256:6d060a2b44ecc198d4e86efd5dab8558a2581b4019970bd8839e1604a243f57e"
             ],
+            "index": "pypi",
             "version": "==0.5.2"
         },
         "six": {
             "hashes": [
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:249000654107a420a40200f1e0b555a79dfd4eff235b2ff60bc77714bd045f2d"
+                "sha256:7cb00cc9b9f92ef8b4391c8a2051f81eeafefe32d63c6b395fd51401e9a39edb"
             ],
-            "version": "==1.2.5"
+            "version": "==1.2.6"
         },
         "tablib": {
             "hashes": [
@@ -192,8 +184,8 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b",
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c"
+                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
+                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
             ],
             "version": "==0.14.1"
         },
@@ -215,10 +207,11 @@
     "develop": {
         "isort": {
             "hashes": [
-                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497",
                 "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
-                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8"
+                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
+                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
+            "index": "pypi",
             "version": "==4.3.4"
         }
     }

--- a/app.py
+++ b/app.py
@@ -4,16 +4,14 @@ import logging
 from flask import Flask, jsonify, request
 from flask.json import JSONEncoder
 from flask_restful import Api, Resource
+from nerium import Query, ResultFormat
 from nerium.contrib.formatter import (AffixFormatter, CompactFormatter,
                                       CsvFormatter)
-from nerium.contrib.resultset import SQLResultSet
 from werkzeug.exceptions import HTTPException
-
 
 # Instantiate and configure app
 app = Flask(__name__)
 api = Api(app)
-
 
 if __name__ != '__main__':
     gunicorn_logger = logging.getLogger('gunicorn.error')
@@ -48,62 +46,29 @@ class BaseRoute(Resource):
 class ReportAPI(Resource):
     """ Calls ResultSet.result() and returns JSON
 
-        Given a query_name, query_extension, and format_ (via URL routes),
+        Given a query_name, and format_ (via URL route/query string),
         this Flask-RESTful Resource submits the query matching the query_name
-        to the appropriate query_extension subclass and optionally format
-        results via the matching format_cls and let Resource do its JSON thing
+        and optionally formats results via the matching format_cls.
+
+        Parent `Resource` class automatically serializes results to JSON
     """
-    # Poor man's plugin registration.
-    # TODO: formalize this with `__subclasses__()` method
-    # TODO: unless and until doing this dynamically with `__subclasses__()`
-    #     let's move this to a separate config
-    query_extension_lookup = {
-        'sql': SQLResultSet,
-    }
-    format_lookup = {
-        'compact': CompactFormatter,
-        'affix': AffixFormatter,
-        'csv': CsvFormatter,
-    }
-
-    def get(self, query_name, query_extension='sql', format_='default'):
-        # Lookup query_extension and fetch result from corresponding class
-        # TODO: Consider adding this to query subdirectory dotenv
-        #      (or something) - With backend_lookup and unique report names,
-        #      this doesn't need to be in url pattern.
-        try:
-            result_cls = self.query_extension_lookup[query_extension]
-        except KeyError:
-            result_cls = SQLResultSet
-
-        loader = result_cls(query_name, **request.args.to_dict())
-        query_result = loader.result_set()
+    def get(self, query_name, format_='default'):
+        # Hand off to Query for query_path resolution and bring back results
+        query = Query(query_name, **request.args.to_dict())
+        query_result = query.result_set()
 
         ne_format = request.args.get("ne_format")
         if ne_format:
             format_ = ne_format
+        
+        # Pass results through matching formatter
+        formatter = ResultFormat(query_result, format_)
+        payload = formatter.formatted_results()
 
-        if format_ in self.format_lookup.keys():
-            format_cls = self.format_lookup[format_]
-            payload = format_cls(query_result).formatted_results()
-        else:
-            """ Return default serialization """
-            # TODO: return format not found message to client(?)
-            if format_:
-                logging.warning(
-                    'format "{}" not found. Using default result ˝format.')
-            if 'error' in query_result[0].keys():
-                # Add 400 code to default-format error messages
-                payload = query_result, 400
-            else:
-                payload = query_result
         return payload
 
 
-api.add_resource(
-    ReportAPI,
-    '/v1/<string:query_name>/',
-    strict_slashes=False)
+api.add_resource(ReportAPI, '/v1/<string:query_name>/', strict_slashes=False)
 api.add_resource(BaseRoute, '/', '/v1/', strict_slashes=False)
 
 

--- a/nerium/__init__.py
+++ b/nerium/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from nerium.main import (ResultSet, ResultFormatter)
+from nerium.main import (Query, ResultSet, ResultFormat, ResultFormatter)

--- a/nerium/contrib/formatter/__init__.py
+++ b/nerium/contrib/formatter/__init__.py
@@ -1,3 +1,4 @@
 from nerium.contrib.formatter.affix import AffixFormatter
 from nerium.contrib.formatter.compact import CompactFormatter
 from nerium.contrib.formatter.csv import CsvFormatter
+from nerium.contrib.formatter.default import DefaultFormatter

--- a/nerium/contrib/formatter/affix.py
+++ b/nerium/contrib/formatter/affix.py
@@ -13,5 +13,6 @@ class AffixFormatter(ResultFormatter):
         formatted['response'] = self.result
         formatted['metadata'] = {}
         formatted['metadata']['executed'] = datetime.datetime.now().isoformat()
+        # TODO: Lib shouldn't depend on Flask. Get these params another way
         formatted['metadata']['params'] = request.args.to_dict()
         return formatted

--- a/nerium/contrib/formatter/default.py
+++ b/nerium/contrib/formatter/default.py
@@ -1,0 +1,8 @@
+from nerium import ResultFormatter
+
+
+class DefaultFormatter(ResultFormatter):
+    """ No-op default
+    """
+    def format_results(self):
+        return self.result

--- a/nerium/contrib/resultset/sql.py
+++ b/nerium/contrib/resultset/sql.py
@@ -18,10 +18,10 @@ class SQLResultSet(ResultSet):
 
     def result(self):
         try:
-            backend_path = self.get_query_path().parent
+            backend_path = self.query_path.parent
             backend = self.backend_lookup(backend_path)
             db = records.Database(backend)
-            result = db.query_file(self.get_query_path(), **self.kwargs)
+            result = db.query_file(self.query_path, **self.kwargs)
             result = result.as_dict()
         except Exception as e:
             result = [{'error': repr(e)}, ]

--- a/nerium/main.py
+++ b/nerium/main.py
@@ -3,6 +3,7 @@
 import abc
 import os
 from abc import ABC
+from importlib import import_module
 from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
@@ -13,8 +14,84 @@ if find_dotenv():
 else:
     load_dotenv('/dotenv/.env')
 
-
 # BASE CLASSES
+
+
+class QueryRegistry():
+    """ Creates a list of dictionaries, mapping query_name to file_system path,
+    file extension, and ResultSet subclass that should be used for query
+    submission.
+
+    Holds Context invoked by Query class to choose a concrete ResultSet
+    subclass to get results from.
+
+    Provides a get_query method to retrieve path and result_cls attributes
+    from a query_name
+    """
+
+    # TODO: Provide for registration from frontmatter or direct config
+
+    def __init__(self):
+        pass
+
+    def lookup_extension(self, _key):
+        # TODO: Define in external config file
+        query_extension_lookup = {
+            'sql': 'SQLResultSet',
+        }
+        try:
+            return query_extension_lookup[_key]
+        except KeyError:
+            return 'SQLResultSet'
+
+    def register_paths(self):
+        query_directory = Path(os.getenv('QUERY_PATH', 'query_files'))
+        flat_directory = list(query_directory.glob('**/*'))
+        registry = [
+            dict(
+                query_name=i.stem,
+                query_path=i,
+                result_cls=self.lookup_extension(i.suffix))
+            for i in flat_directory if i.is_file()
+        ]
+        return registry
+
+    def get_query(self, query_name):
+        try:
+            query = next(
+                i for i in self.register_paths()
+                if query_name == i['query_name'])
+            return query
+        except StopIteration:
+            return None
+
+
+class Query():
+    """ Finds query in registry, and looks up ResultSet subclass from
+    path file extension. Submits query_path to ResultSet and returns results
+    """
+
+    def __init__(self, query_name, **kwargs):
+        self.query_name = query_name
+        self.kwargs = kwargs
+
+    def result_set(self):
+        registry = QueryRegistry()
+        query = registry.get_query(self.query_name)
+        if not query:
+            return [{
+                'error':
+                "No query found matching {}".format(self.query_name)
+            }]
+        else:
+            query_path = query['query_path']
+            result_mods = import_module('nerium.contrib.resultset')
+            result_cls = getattr(result_mods, query['result_cls'])
+            loader = result_cls(query_path, **self.kwargs)
+            query_result = loader.result()
+            return query_result
+
+
 class ResultSet(ABC):
     """Generic result set class template.
 
@@ -23,59 +100,49 @@ class ResultSet(ABC):
 
 
     Args:
-        query_name (str): Name of chosen query file, without the extension
+        query_path (path-like object): Path to query file
         kwargs: Parameter keys and values to bind to query
 
     Usage:
         Subclass and provide a 'result' method
     """
 
-    def __init__(self, query_name, **kwargs):
-        self.query_name = query_name
+    def __init__(self, query_path, **kwargs):
+        self.query_path = query_path
         self.kwargs = kwargs
-
-    def get_query_path(self):
-        query_directory = Path(os.getenv('QUERY_PATH', 'query_files'))
-        flat_directory = list(query_directory.glob('**/*'))
-        files = [i for i in flat_directory if i.is_file()]
-        try:
-            query_path = next(
-                i for i in sorted(files) if i.stem == self.query_name)
-            return query_path
-        except StopIteration:
-            return None
-
-    def result_set(self):
-        """ if your functionResultSet subclass needs no script,
-            simply return self.result() here.
-        """
-        if not self.get_query_path():
-            return [
-                {
-                    'error': "No query found matching {}".format(
-                        self.query_name)
-                }
-            ]
-        else:
-            return self.result()
 
     @abc.abstractmethod
     def result(self):
-        """ Return query results as a JSON-serializable Python structure
+        """ Given a query_path, return results as a serializable Python structure
         (generally a list of dictionaries)
         """
         return
 
 
-class ResultFormatter(ABC):
-    def __init__(self, result):
+class ResultFormat(ABC):
+    def __init__(self, result, format_):
         self.result = result
+        self.format_ = format_
 
     def formatted_results(self):
+        format_lookup = {
+            'affix': 'AffixFormatter',
+            'compact': 'CompactFormatter',
+            'csv': 'CsvFormatter',
+            'default': 'DefaultFormatter',
+        }
         if 'error' in self.result[0].keys():
             return self.result, 400
         else:
-            return self.format_results()
+            format_cls_name = format_lookup[self.format_]
+            format_mods = import_module('nerium.contrib.formatter')
+            format_cls = getattr(format_mods, format_cls_name)
+            return format_cls(self.result).format_results()
+
+
+class ResultFormatter(ABC):
+    def __init__(self, result):
+        self.result = result
 
     @abc.abstractmethod
     def format_results(self):

--- a/tests.py
+++ b/tests.py
@@ -5,11 +5,10 @@ import unittest
 from tempfile import NamedTemporaryFile
 
 import app
-import nerium
+from nerium import Query
 
 # TODO: test moar methods
 
-# TODO: make tests run+improve
 os.environ['DATABASE_URL'] = 'sqlite:///'
 # Fixtures
 EXPECTED = [{
@@ -53,23 +52,23 @@ def tearDownModule():
     os.remove(sql_file.name)
 
 
-class TestSQLResultSet(unittest.TestCase):
+class TestQuery(unittest.TestCase):
     def test_results_expected(self):
-        loader = nerium.contrib.resultset.sql.SQLResultSet(query_name)
+        loader = Query(query_name)
         result = loader.result_set()
         self.assertEqual(result, EXPECTED)
 
 
-class TestSQLAPI(unittest.TestCase):
+class TestAPI(unittest.TestCase):
     def setUp(self):
         self.app = app.app.test_client()
 
     def test_response(self):
-        endpoint = '/v1/sql/{}/'.format(query_name)
+        endpoint = '/v1/{}/'.format(query_name)
         response = self.app.get(endpoint)  # noqa F841
 
     def test_response_expected(self):
-        endpoint = '/v1/sql/{}/'.format(query_name)
+        endpoint = '/v1/{}/'.format(query_name)
         response = self.app.get(endpoint)
         self.assertEqual(EXPECTED, json.loads(response.get_data()))
 


### PR DESCRIPTION
- ResultSet subclass strategy chosen by file extension
- ResultFormatter strategy specified by format variable
- Flask app no longer calls subclasses directly, lib handles this
- Default format is a ResultFormatter subclass (allows for consisten error handling)
- Tests pass!