### PR TITLE
Add a sum formatter for groupings

### DIFF
--- a/nerium/contrib/formatter/__init__.py
+++ b/nerium/contrib/formatter/__init__.py
@@ -2,3 +2,4 @@ from nerium.contrib.formatter.affix import AffixFormatter
 from nerium.contrib.formatter.compact import CompactFormatter
 from nerium.contrib.formatter.csv import CsvFormatter
 from nerium.contrib.formatter.default import DefaultFormatter
+from nerium.contrib.formatter.sum import SumFormatter

--- a/nerium/contrib/formatter/sum.py
+++ b/nerium/contrib/formatter/sum.py
@@ -2,6 +2,7 @@ import datetime
 
 from nerium import ResultFormatter
 
+
 class SumFormatter(ResultFormatter):
 
     def transform_grouping_sets(self, result):

--- a/nerium/contrib/formatter/sum.py
+++ b/nerium/contrib/formatter/sum.py
@@ -15,22 +15,12 @@ class SumFormatter(ResultFormatter):
                 groupings.append(output_row)
         return (raw_data, groupings)
 
-    def is_float(self, maybefloat):
-        if isinstance(maybefloat, float):
-            return True
-        else:
-            try:
-                float(maybefloat)
-                return True
-            except:
-                return False
-
     def format_results(self):
         raw = self.result
         formatted = {}
         formatted['error'] = False
         formatted['response'] = {}
-        formatted['response']['summary'] = {}
+        formatted['response']['summary'] = []
         formatted['metadata'] = {}
         formatted['metadata']['executed'] = datetime.datetime.now().isoformat()
         formatted['metadata']['params'] = self.kwargs
@@ -39,15 +29,5 @@ class SumFormatter(ResultFormatter):
             return formatted
         raw_data, groupings = self.transform_grouping_sets(raw)
         formatted['response']['result'] = raw_data
-        #figure out what the groupings relate to by looking at what columns are and aren't supplied with it.
-        for dictionary in groupings:
-            value_set = []
-            for key, value in dictionary.items():
-                if value != None and isinstance(value, str) and not self.is_float(value):
-                    value_set.append(value)
-            if value_set == []:
-                value_set = 'overall_total'
-            else:
-                value_set = '_'.join(value_set)
-            formatted['response']['summary'][value_set] = {key: val for key, val in dictionary.items() if val != None}
+        formatted['response']['summary'] = groupings
         return formatted

--- a/nerium/contrib/formatter/sum.py
+++ b/nerium/contrib/formatter/sum.py
@@ -1,0 +1,53 @@
+import datetime
+
+from nerium import ResultFormatter
+
+class SumFormatter(ResultFormatter):
+
+    def transform_grouping_sets(self, result):
+        raw_data = []
+        groupings = []
+        for row in result:
+            output_row = {key: val for key, val in row.items() if key != 'grouping'}
+            if row['grouping'] == 0:
+                raw_data.append(output_row)
+            elif row['grouping'] > 0:
+                groupings.append(output_row)
+        return (raw_data, groupings)
+
+    def is_float(self, maybefloat):
+        if isinstance(maybefloat, float):
+            return True
+        else:
+            try:
+                float(maybefloat)
+                return True
+            except:
+                return False
+
+    def format_results(self):
+        raw = self.result
+        formatted = {}
+        formatted['error'] = False
+        formatted['response'] = {}
+        formatted['response']['summary'] = {}
+        formatted['metadata'] = {}
+        formatted['metadata']['executed'] = datetime.datetime.now().isoformat()
+        formatted['metadata']['params'] = self.kwargs
+        if not 'grouping' in raw[0].keys():
+            formatted['response']['result'] = raw
+            return formatted
+        raw_data, groupings = self.transform_grouping_sets(raw)
+        formatted['response']['result'] = raw_data
+        #figure out what the groupings relate to by looking at what columns are and aren't supplied with it.
+        for dictionary in groupings:
+            value_set = []
+            for key, value in dictionary.items():
+                if value != None and isinstance(value, str) and not self.is_float(value):
+                    value_set.append(value)
+            if value_set == []:
+                value_set = 'overall_total'
+            else:
+                value_set = '_'.join(value_set)
+            formatted['response']['summary'][value_set] = {key: val for key, val in dictionary.items() if val != None}
+        return formatted

--- a/nerium/main.py
+++ b/nerium/main.py
@@ -131,6 +131,7 @@ class ResultFormat(ABC):
             'compact': 'CompactFormatter',
             'csv': 'CsvFormatter',
             'default': 'DefaultFormatter',
+            'sum': 'SumFormatter',
         }
         format_cls_name = format_lookup[self.format_]
         format_mods = import_module('nerium.contrib.formatter')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(Path(__file__).parent / 'README.md') as f:
 
 setup(
     name='nerium',
-    version='0.1.2',
+    version='0.1.3',
     packages=find_packages(),
     description='The little business intelligence engine that could',
     long_description=long_description,

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import unittest
@@ -63,6 +64,85 @@ class TestResults(unittest.TestCase):
         formatter = ResultFormat(result, format_='default')
         formatted_results = formatter.formatted_results()
         self.assertEqual(formatted_results, EXPECTED)
+
+class TestContribFormatters(unittest.TestCase):
+    AFFIX_EXPECTED = { 'error': False,
+                       'response': [{
+                                    'foo': 1.25,
+                                    'bar': '2017-09-09',
+                                    'quux': 'Hello',
+                                    'quuux': 'Björk Guðmundsdóttir'
+                                }, {
+                                    'foo': 42,
+                                    'bar': '2031-05-25',
+                                    'quux': 'yo',
+                                    'quuux': 'ƺƺƺƺ'
+                                }],
+                        'metadata': {'executed': 'N/A',  
+                                     'params': {}}
+                      }
+    
+    COMPACT_EXPECTED = {
+                        'columns': ['foo', 'bar', 'quux', 'quuux'],
+                        'data': [
+                             (1.25, '2017-09-09', 'Hello', 'Björk Guðmundsdóttir'),
+                             (42, '2031-05-25', 'yo', 'ƺƺƺƺ')]
+    }
+    CSV_EXPECTED = 'foo,bar,quux,quuux\r\n1.25,2017-09-09,Hello,Björk Guðmundsdóttir\r\n42,2031-05-25,yo,ƺƺƺƺ\r\n'
+
+    SUM_EXPECTED = { 'error': False,
+                     'response': {'summary': {},
+                                  'result':[{
+                                             'foo': 1.25,
+                                             'bar': '2017-09-09',
+                                             'quux': 'Hello',
+                                             'quuux': 'Björk Guðmundsdóttir'
+                                         }, {
+                                             'foo': 42,
+                                             'bar': '2031-05-25',
+                                             'quux': 'yo',
+                                             'quuux': 'ƺƺƺƺ'
+                                         }]
+                                },
+                     'metadata': {'executed': 'N/A',  
+                                  'params': {}}
+                      }
+
+    def test_results_affix(self):
+        loader = Query(query_name)
+        result = loader.result_set()
+        formatter = ResultFormat(result, format_='affix')
+        formatted_results = formatter.formatted_results()
+        #match shape
+        self.assertEqual(formatted_results.keys(), self.AFFIX_EXPECTED.keys())
+        self.assertEqual(formatted_results['response'],
+                         self.AFFIX_EXPECTED['response'])
+        self.assertEqual(formatted_results['error'],
+                         self.AFFIX_EXPECTED['error'])
+        self.assertEqual(formatted_results['metadata']['params'],
+                         self.AFFIX_EXPECTED['metadata']['params'])
+
+    def test_results_compact(self):
+        loader = Query(query_name)
+        result = loader.result_set()
+        formatter = ResultFormat(result, format_='compact')
+        formatted_results = formatter.formatted_results()
+        self.assertEqual(formatted_results, self.COMPACT_EXPECTED)
+    
+    def test_results_csv(self):
+        loader = Query(query_name)
+        result = loader.result_set()
+        formatter = ResultFormat(result, format_='csv')
+        formatted_results = formatter.formatted_results()
+        self.assertEqual(formatted_results, self.CSV_EXPECTED) 
+    
+    def test_results_sum(self):
+        loader = Query(query_name)
+        result = loader.result_set()
+        formatter = ResultFormat(result, format_='sum')
+        formatted_results = formatter.formatted_results()
+        self.assertEqual(formatted_results['response']['summary'],
+                         self.SUM_EXPECTED['response']['summary'])  
 
 
 class TestAPI(AioHTTPTestCase):

--- a/tests.py
+++ b/tests.py
@@ -39,30 +39,6 @@ TEST_SQL = """select cast(1.25 as float) as foo  -- float check
                    , 'ƺƺƺƺ';
            """
 
-#gross
-TEST_SUM_SQL = """select 0 as grouping,
-                        'hello' as label,
-                        100 as part
-                union
-                select 0 as grouping,
-                        'hello' as label,
-                        50 as part
-                union
-                select 0 as grouping,
-                        'word' as label,
-                        20 as part
-                union 
-                select 1 as grouping,
-                    'hello' as label,
-                    150 as part
-                union
-                select 1 as grouping,
-                    'word' as label,
-                    20 as part
-                union
-                select 3 as grouping,
-                    NULL as label,
-                    170 as part"""
 
 def setUpModule():
     global sql_file
@@ -147,25 +123,48 @@ class TestContribCSVFormatter(unittest.TestCase):
         self.assertEqual(formatted_results, self.CSV_EXPECTED) 
 
 class TestContribSumFormatter(unittest.TestCase):
+    TEST_SUM_SQL = """select 0 as grouping,
+                        'hello' as label,
+                        100 as part
+                union
+                select 0 as grouping,
+                        'hello' as label,
+                        50 as part
+                union
+                select 0 as grouping,
+                        'word' as label,
+                        20 as part
+                union 
+                select 1 as grouping,
+                    'hello' as label,
+                    150 as part
+                union
+                select 1 as grouping,
+                    'word' as label,
+                    20 as part
+                union
+                select 3 as grouping,
+                    NULL as label,
+                    170 as part"""
+    
     SUM_EXPECTED = {'error': False,
-                    'response': {'summary': {"hello": {
-                                                    "label": "hello",
-                                                    "part": 150
-                                                },
-                                                "overall_total": {
-                                                    "part": 170
-                                                },
-                                                "word": {
-                                                    "label": "word",
-                                                    "part": 20
-                                                }},
+                    'response': {'summary': [{
+                                                "label": "hello",
+                                                "part": 150
+                                             }, {
+                                                "label": "word",
+                                                "part": 20
+                                             }, {
+                                                "label": None,
+                                                "part": 170
+                                             }],
                                  'result':[{
                                         "label": "hello",
                                         "part": 50
-                                    }, {
+                                        }, {
                                         "label": "hello",
                                         "part": 100
-                                    }, {
+                                        }, {
                                         "label": "word",
                                         "part": 20
                                     }]
@@ -174,7 +173,7 @@ class TestContribSumFormatter(unittest.TestCase):
                                   'params': {}}
                       }
     NO_SUM_EXPECTED = { 'error': False,
-                        'response': {'summary': {},
+                        'response': {'summary': [],
                                      'result':[{
                                                 'foo': 1.25,
                                                 'bar': '2017-09-09',
@@ -206,7 +205,7 @@ class TestContribSumFormatter(unittest.TestCase):
             dir='query_files', suffix='.sql', mode='w',
             delete=False) as _sql_sum_file:
             sql_sum_file = _sql_sum_file
-            sql_sum_file.write(TEST_SUM_SQL)
+            sql_sum_file.write(self.TEST_SUM_SQL)
             _report_name = os.path.basename(sql_sum_file.name)
             sum_query_name = os.path.splitext(_report_name)[0]
 
@@ -219,7 +218,7 @@ class TestContribSumFormatter(unittest.TestCase):
         self.assertEqual(formatted_results['response']['result'],
                          self.SUM_EXPECTED['response']['result'])
         os.remove(sql_sum_file.name)
-
+    
 
 class TestAPI(AioHTTPTestCase):
     async def get_application(self):

--- a/tests.py
+++ b/tests.py
@@ -7,8 +7,8 @@ from tempfile import NamedTemporaryFile
 
 import aiohttp
 from aiohttp.test_utils import AioHTTPTestCase
-from nerium.app import app
 from nerium import Query, ResultFormat
+from nerium.app import app
 
 # TODO: tests for contrib modules
 


### PR DESCRIPTION
I believe this could definitely use some work, but it seemed useful to have a resultformatter which looked at postgres grouping set related things to extract sums from a result set.
The look of result sets is seen through the testing module.

Along with this, test coverage has been improved to cover all of the different result formatters.