### PR TITLE
Add `reports` discovery endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.8
-LABEL maintainer='thomas.yager-madden@adops.com'
+LABEL maintainer='yagermadden@gmail.com'
 
 ENV PORT 5000
 # Install python3

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,17 @@ ENV PORT 5000
 # Install python3
 # Not using python:3-alpine to avoid
 #   psycopg2 starting a separate python3 install'
-RUN apk add --no-cache python3 py3-psycopg2 python3-dev build-base git
+RUN apk add --no-cache python3 py3-psycopg2 python3-dev build-base 
 # Copy in the code
 COPY . /app
 
 WORKDIR /app
 
 # install from code currently in repo
-RUN pip3 install --upgrade pip pipenv \
+RUN pip3 install --upgrade pipenv \
     && pipenv install --pre --system
+
+RUN apk del python3-dev build-base
 
 VOLUME /app/query_files
 VOLUME /app/format_files

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -32,16 +32,16 @@
         },
         "apispec": {
             "hashes": [
-                "sha256:9300142aa93e0c020e6b223a196cd2103ac4a61bcceea7dba894c0959b72e327",
-                "sha256:bcfe21887ba7c6e94c4be00f10564478a0d9109bb8e574aae97442909fd69b31"
+                "sha256:8f89282a5474e449ce158b3c9f7e3948a207c89d5eb624231bbb6ea87fcf9f4a",
+                "sha256:cc1e5454df092b6d0ae84f29cf6b4cb4b552a4d76255f6e7f2e2f123102b0dcb"
             ],
-            "version": "==1.1.0"
+            "version": "==1.2.0"
         },
         "apistar": {
             "hashes": [
-                "sha256:004163356c8834da60ad44c936540a40f277e86540caefdad6ccd9da0993e2fa"
+                "sha256:8da0d3f15748c8ed6e68914ba5b8f6dd5dff5afbe137950d07103575df0bce73"
             ],
-            "version": "==0.7.1"
+            "version": "==0.7.2"
         },
         "asgiref": {
             "hashes": [
@@ -166,10 +166,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "markupsafe": {
             "hashes": [
@@ -206,10 +206,10 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:7f9aba737a59dd3c6c6c79846f1df2fbfe036c17f038bbc2c83911b7304a90e1",
-                "sha256:b41cc52fe0491bdb8aa3e2186ca57d478d9ef69dba87fe37d309aa8a08fd30dd"
+                "sha256:e23b8618275225ec111225dc01301e1cc0c3cbb4e41307b35136f891a29d3949",
+                "sha256:ea2a241f2ea69bb0863f2c00b907a8e22d7dd8b6d5b9960135906037c9dd7068"
             ],
-            "version": "==3.0.0rc4"
+            "version": "==3.0.0rc5"
         },
         "nerium": {
             "editable": true,
@@ -229,9 +229,9 @@
         },
         "parse": {
             "hashes": [
-                "sha256:870dd675c1ee8951db3e29b81ebe44fd131e3eb8c03a79483a58ea574f3145c2"
+                "sha256:1b68657434d371e5156048ca4a0c5aea5afc6ca59a2fea4dd1a575354f617142"
             ],
-            "version": "==1.11.1"
+            "version": "==1.12.0"
         },
         "promise": {
             "hashes": [
@@ -327,10 +327,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:781fb7b9d194ed3fc596b8f0dd4623ff160e3e825dd8c15472376a438c19598b"
+                "sha256:d5432832f91d200c3d8b473a266d59442d825f9ea744c467e68c5d9a9479fbce"
             ],
             "markers": "python_version >= '3.0'",
-            "version": "==1.3.1"
+            "version": "==1.3.2"
         },
         "sqlparse": {
             "hashes": [
@@ -354,9 +354,9 @@
         },
         "typesystem": {
             "hashes": [
-                "sha256:94574c7a2092b8d85e92af137e4e4f60d0fefe609ef01d64f972afe16437b707"
+                "sha256:aa01ac52370a7e5996960c8a899da0f939753bc49d405e92dea5cb1f6bc3700a"
             ],
-            "version": "==0.2.0"
+            "version": "==0.2.2"
         },
         "urllib3": {
             "hashes": [
@@ -367,9 +367,9 @@
         },
         "uvicorn": {
             "hashes": [
-                "sha256:d700b65169820fc260f39402b7f966c178691daaa40cb376cad99d7cd737f772"
+                "sha256:d96fb442d9ce9c1dba67360035161d392970b8e6b0ed797d2cefed24abfd78bc"
             ],
-            "version": "==0.7.0b1"
+            "version": "==0.7.0b2"
         },
         "uvloop": {
             "hashes": [
@@ -473,39 +473,37 @@
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:19a2d1f3567b30f6c2bb3baea23f74f69d51f0c06c2e2082d0d9c28b0733a4c2",
-                "sha256:2b69cf4b0fa2716fd977aa4e1fd39af6110eb47b2bb30b4e5a469d8fbecfc102",
-                "sha256:2e952fa17ba48cbc2dc063ddeec37d7dc4ea0ef7db0ac1eda8906365a8543f31",
-                "sha256:348b49dd737ff74cfb5e663e18cb069b44c64f77ec0523b5794efafbfa7df0b8",
-                "sha256:3d72a5fdc5f00ca85160915eb9a973cf9a0ab8148f6eda40708bf672c55ac1d1",
-                "sha256:4957452f7868f43f32c090dadb4188e9c74a4687323c87a882e943c2bd4780c3",
-                "sha256:5138cec2ee1e53a671e11cc519505eb08aaaaf390c508f25b09605763d48de4b",
-                "sha256:587098ca4fc46c95736459d171102336af12f0d415b3b865972a79c03f06259f",
-                "sha256:5b79368bcdb1da4a05f931b62760bea0955ee2c81531d8e84625df2defd3f709",
-                "sha256:5cf43807392247d9bc99737160da32d3fa619e0bfd85ba24d1c78db205f472a4",
-                "sha256:676d1a80b1eebc0cacae8dd09b2fde24213173bf65650d22b038c5ed4039f392",
-                "sha256:6b0211ecda389101a7d1d3df2eba0cf7ffbdd2480ca6f1d2257c7bd739e84110",
-                "sha256:79cde4660de6f0bb523c229763bd8ad9a93ac6760b72c369cf1213955c430934",
-                "sha256:7aba9786ac32c2a6d5fb446002ed936b47d5e1f10c466ef7e48f66eb9f9ebe3b",
-                "sha256:7c8159352244e11bdd422226aa17651110b600d175220c451a9acf795e7414e0",
-                "sha256:945f2eedf4fc6b2432697eb90bb98cc467de5147869e57405bfc31fa0b824741",
-                "sha256:96b4e902cde37a7fc6ab306b3ac089a3949e6ce3d824eeca5b19dc0bedb9f6e2",
-                "sha256:9a7bccb1212e63f309eb9fab47b6eaef796f59850f169a25695b248ca1bf681b",
-                "sha256:a3bfcac727538ec11af304b5eccadbac952d4cca1a551a29b8fe554e3ad535dc",
-                "sha256:b19e9f1b85c5d6136f5a0549abdc55dcbd63aba18b4f10d0d063eb65ef2c68b4",
-                "sha256:b664011bb14ca1f2287c17185e222f2098f7b4c857961dbcf9badb28786dbbf4",
-                "sha256:bde7959ef012b628868d69c474ec4920252656d0800835ed999ba5e4f57e3e2e",
-                "sha256:cb095a0657d792c8de9f7c9a0452385a309dfb1bbbb3357d6b1e216353ade6ca",
-                "sha256:d16d42a1b9772152c1fe606f679b2316551f7e1a1ce273e7f808e82a136cdb3d",
-                "sha256:d444b1545430ffc1e7a24ce5a9be122ccd3b135a7b7e695c5862c5aff0b11159",
-                "sha256:d93ccc7bf409ec0a23f2ac70977507e0b8a8d8c54e5ee46109af2f0ec9e411f3",
-                "sha256:df6444f952ca849016902662e1a47abf4fa0678d75f92fd9dd27f20525f809cd",
-                "sha256:e63850d8c52ba2b502662bf3c02603175c2397a9acc756090e444ce49508d41e",
-                "sha256:ec43358c105794bc2b6fd34c68d27f92bea7102393c01889e93f4b6a70975728",
-                "sha256:f4c6926d9c03dadce7a3b378b40d2fea912c1344ef9b29869f984fb3d2a2420b"
+                "sha256:163d3ee445a0b4c0109877da9e46271aacf4e5e3d60ae7368669555c30f13e7c",
+                "sha256:1af0bfe7b0c13a0e613a27311fd4f9c5d024e8fc0f4b3d284e7df02a58a11fc0",
+                "sha256:2169c3a1bf52d5b30cc98625b5919a964c571a32e8646be20be6c7e3e82079de",
+                "sha256:218f079fa48e2ef812dc3d3ce6ec2f67ac56427ba4b038d5d6331f2cceb489c2",
+                "sha256:26a958930687e94c4c6c73c171e4d4783b82ae4e16aa3424e6bcd4529bceedf0",
+                "sha256:2c7c195aef3acdbc853942bc674844031a732890d2fee88a324298ed376b6c2b",
+                "sha256:2ecdbfed7004669472bfa27c8d51012c717c241c7154ae17e4c8f93024043525",
+                "sha256:345fc31b71a90ada1b51826537917b19a1af685a91c0f066787069c184d7d00f",
+                "sha256:378a06649503f548be5f1e9eec2e94cc1d6138250b82a08dcc6151bca8cec107",
+                "sha256:3f300bf2930e501dde09605de85cb2b84c2638e2c954be02a3c86f28176d3525",
+                "sha256:6c2f66c653ce8bbd7e789d0f7f92c3f9fea881b55226f0ae5ee550cce9e3cf0e",
+                "sha256:6fccbac2633831b877a8fbf865f7082d34895e82a015795a9f80f99a2efe2576",
+                "sha256:7a166f8ccb6888358d3e67795b057540ea7caa71ab9e089b0cb0097f01088965",
+                "sha256:8f6b84f887ec6fef6c1796779f8ec2603dc7e9ef52bc9269de719d4bcbdaebbb",
+                "sha256:92cf3ceb7bb90cf35b8bd993c640b15d4832ba0e142a3b9da5006ef217da595d",
+                "sha256:a20dfdf73f56da674926a3811929cff9fd23b9af90be9a6c36ac246a3486eef3",
+                "sha256:a84415df4689251556c961e4fe3b25d30e32f00faa8064ce0909458dbe0d67b2",
+                "sha256:ab1aa1cd50df3860f624c9713ee9e690eefd4e049d3a4d86577bab6e741e9616",
+                "sha256:abc9dcf85e75a8687f2a6d560c0c1a2593e8e34ba6f9ad6721f8212c5de179a2",
+                "sha256:c10454710a81a2f4b1ff4d1c83ac2cec63e0e55845a56324991514af5b1299d0",
+                "sha256:c38f80719e4dfae7a6311a4f091f07f4fb2fb5d602352015d5639f63f8fabb68",
+                "sha256:d75cf00605630b2cfefa5c62373c605dcda1cc0d607902847dbb8e8e9b67c1ce",
+                "sha256:dce15cb6ef604c9e38fdaa848f58f83153ade9f4aa5e4cf5812aa27163561750",
+                "sha256:e7e0db4311bb76bf3f6e0380f71912cfa6d0be7cc635e3772476050b0dabdabd",
+                "sha256:eac59cae78dfe3fbf7ece25c170d7a152f88df7643381aa5e7344c2028a8d8d4",
+                "sha256:ead7b3e1567bd14cacd44279c5e42cd19f54b9feed39180220253f4fbe3abd56",
+                "sha256:ed772a5e8e7e5dd6bede960a86940c17cf653c7f158dafa5d52e919b676f10ba",
+                "sha256:f2d73131acb94afa45de8b6b8a4bfb21bbe3736633d6478e53247f19dd8c299c"
             ],
             "index": "pypi",
-            "version": "==2.7.7"
+            "version": "==2.8.1"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c4c3a200098890d00c6bc323ad6c8bd97719c7cdf0d53537f25b91baf80ae8c9"
+            "sha256": "8f0d265330426fa308fed222495ba0df855e34f9266667f8cb6be6b9c16541de"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,23 +32,23 @@
         },
         "apispec": {
             "hashes": [
-                "sha256:57a7b81fd19fff0663a7e5ffd196eaea79b5364151ed2b65533be36d55e0229c",
-                "sha256:b45def53903516e67e8584ee41f34bc60c3e4acace6892b69340293ea20f3caa"
+                "sha256:9300142aa93e0c020e6b223a196cd2103ac4a61bcceea7dba894c0959b72e327",
+                "sha256:bcfe21887ba7c6e94c4be00f10564478a0d9109bb8e574aae97442909fd69b31"
             ],
-            "version": "==1.0.0"
+            "version": "==1.1.0"
         },
         "apistar": {
             "hashes": [
-                "sha256:4338b24468b49526ceac4a8f84046056081ee747f373ca8d0647bd6b2344c895"
+                "sha256:004163356c8834da60ad44c936540a40f277e86540caefdad6ccd9da0993e2fa"
             ],
-            "version": "==0.6.0"
+            "version": "==0.7.1"
         },
         "asgiref": {
             "hashes": [
-                "sha256:9b05dcd41a6a89ca8c6e7f7e4089c3f3e76b5af60aebb81ae6d455ad81989c97",
-                "sha256:b21dc4c43d7aba5a844f4c48b8f49d56277bc34937fd9f9cb93ec97fde7e3082"
+                "sha256:bd5a17ca8742dd131b64b7cb67c79daec290d3feb46c9084a3a94cfbe5d62089",
+                "sha256:c7a9f05e8bf5db5ce582aa4c4622621fc23c110ee79202e45dd5218ed5eba9f5"
             ],
-            "version": "==2.3.2"
+            "version": "==3.0.0"
         },
         "async-timeout": {
             "hashes": [
@@ -59,10 +59,10 @@
         },
         "backports.csv": {
             "hashes": [
-                "sha256:bed884eeb967c8d6f517dfcf672914324180f1e9ceeb0376fde2c4c32fd7008d",
-                "sha256:f68c7115c7fbe6d4b4104327d2e677efb38aa09bd7f877b47a6de18e44975510"
+                "sha256:1277dfff73130b2e106bf3dd347adb3c5f6c4340882289d88f31240da92cbd6d",
+                "sha256:21f6e09bab589e6c1f877edbc40277b65e626262a86e69a70137db714eaac5ce"
             ],
-            "version": "==1.0.6"
+            "version": "==1.0.7"
         },
         "certifi": {
             "hashes": [
@@ -262,19 +262,19 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:544a0050e76e9b60751c58617fa28c253ad5d23af2e5f0b1c250390bf90bb0df",
-                "sha256:594bf80477a58b6fd53e8b3f24ccf965c25eeeb6e05e4b1fb18c82c2d2090603",
-                "sha256:75e20ca689d0a2bf0c84f0e2028cc68ebef34b213fa66d73c410c53f870c49f4",
-                "sha256:994da68a1dc1050f290f8017f044172360b608c0f2562b47645ecc69d7a61c0a",
-                "sha256:ad902e00088c50bdced94a57b819c24fdadaeaed5494df7a9a67d63774f210fd",
-                "sha256:b11aff75875ffc73541c4e4b1ac2f5e21717c1fc4396238943b9a44d962e74e1",
-                "sha256:bc733b5a9047c3e4848c0e80eeacfa6a799139242606410260c5450d665ea58c",
-                "sha256:d960c68931b96bb215f385baa8ef867b8ebac66af60fa06cc1008f963848c7ad",
-                "sha256:dd461c04e6a91e4eef7d5b75c1fc1c7013d3f8d354033b16526baadddd524079",
-                "sha256:e4d6b5d6218a06f3141189d75c93876dd525a6d15f1b00ef4f274726c93719f1",
-                "sha256:f3c386fa12415bde8a0162745c4badf98fe171c6dfd67e54831f05ec88feeebb"
+                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
+                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
+                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
+                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
+                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
+                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
+                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
+                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
+                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
+                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
+                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
             ],
-            "version": "==5.1b5"
+            "version": "==5.1"
         },
         "records": {
             "hashes": [
@@ -334,11 +334,10 @@
         },
         "sqlparse": {
             "hashes": [
-                "sha256:ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec",
-                "sha256:d9cf190f51cbb26da0412247dfe4fb5f4098edb73db84e02f9fc21fdca31fed4"
+                "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",
+                "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
             ],
-            "index": "pypi",
-            "version": "==0.2.4"
+            "version": "==0.3.0"
         },
         "starlette": {
             "hashes": [
@@ -353,6 +352,12 @@
             ],
             "version": "==0.13.0"
         },
+        "typesystem": {
+            "hashes": [
+                "sha256:94574c7a2092b8d85e92af137e4e4f60d0fefe609ef01d64f972afe16437b707"
+            ],
+            "version": "==0.2.0"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
@@ -362,25 +367,25 @@
         },
         "uvicorn": {
             "hashes": [
-                "sha256:8d523d0a003a874245025295b0c1233a762402c0d4c3988017401c6b461c83e9"
+                "sha256:d700b65169820fc260f39402b7f966c178691daaa40cb376cad99d7cd737f772"
             ],
-            "version": "==0.5.1"
+            "version": "==0.7.0b1"
         },
         "uvloop": {
             "hashes": [
-                "sha256:198fe0c196056930ec6c4a0a878e531a66d15467ca7c74a875aa90271f0c6e3f",
-                "sha256:1c175f47d34b84e33c0e312f4987c927ea004afc3a5f05d2f0f610d71d0e4c89",
-                "sha256:1c47f197be8f0a3c651dd20be1e1bd43268186246f246d4e86c91e95a89e4865",
-                "sha256:3fd4943570d20e8cd4d9f0a3190ebd5cf040e5610b685e05c878128a11f7ad14",
-                "sha256:435e232869923fd2248e4ca0ad73e24a5b4debf40bed9dcde133cfe1bef98a7a",
-                "sha256:9cfdb966ae804c46b96c92207dfd2174935ffc70e706e42e1c94c60d16dbe860",
-                "sha256:a585781443eeb2edb858f8c08c503aac237a5f1bebf0c84ea8340cc337afa408",
-                "sha256:b296493e033846e46488a6aa227a75c790091f5ee5456ec637bb0badad1e8851",
-                "sha256:c684047c6cf6d697ba37872fb1b4489012ea91f3f802c8fbb9c367c4902e88dc",
-                "sha256:da5a59d8812188b57b5783c7fb78891d14dd1050b6259680e0dbd4253d7d0f64"
+                "sha256:0fcd894f6fc3226a962ee7ad895c4f52e3f5c3c55098e21efb17c071849a0573",
+                "sha256:2f31de1742c059c96cb76b91c5275b22b22b965c886ee1fced093fa27dde9e64",
+                "sha256:459e4649fcd5ff719523de33964aa284898e55df62761e7773d088823ccbd3e0",
+                "sha256:67867aafd6e0bc2c30a079603a85d83b94f23c5593b3cc08ec7e58ac18bf48e5",
+                "sha256:8c200457e6847f28d8bb91c5e5039d301716f5f2fce25646f5fb3fd65eda4a26",
+                "sha256:958906b9ca39eb158414fbb7d6b8ef1b7aee4db5c8e8e5d00fcbb69a1ce9dca7",
+                "sha256:ac1dca3d8f3ef52806059e81042ee397ac939e5a86c8a3cea55d6b087db66115",
+                "sha256:b284c22d8938866318e3b9d178142b8be316c52d16fcfe1560685a686718a021",
+                "sha256:c48692bf4587ce281d641087658eca275a5ad3b63c78297bbded96570ae9ce8f",
+                "sha256:fefc3b2b947c99737c348887db2c32e539160dcbeb7af9aa6b53db7a283538fe"
             ],
             "markers": "sys_platform != 'win32'",
-            "version": "==0.12.1"
+            "version": "==0.12.2"
         },
         "websockets": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -32,10 +32,10 @@
         },
         "apispec": {
             "hashes": [
-                "sha256:8f89282a5474e449ce158b3c9f7e3948a207c89d5eb624231bbb6ea87fcf9f4a",
-                "sha256:cc1e5454df092b6d0ae84f29cf6b4cb4b552a4d76255f6e7f2e2f123102b0dcb"
+                "sha256:9f7323abd9f0bbb12f98a155a9ec436a048897d3550babc935664f3dc26ad507",
+                "sha256:a350fa2f87d1462acc4b3a52ce2ddaf04805b44911e053ee0a68eb50919ea690"
             ],
-            "version": "==1.2.0"
+            "version": "==1.3.0"
         },
         "apistar": {
             "hashes": [
@@ -45,10 +45,10 @@
         },
         "asgiref": {
             "hashes": [
-                "sha256:bd5a17ca8742dd131b64b7cb67c79daec290d3feb46c9084a3a94cfbe5d62089",
-                "sha256:c7a9f05e8bf5db5ce582aa4c4622621fc23c110ee79202e45dd5218ed5eba9f5"
+                "sha256:48afe222aefece5814ae90aae394964eada5a4604e67f9397f7858e8957e9fdf",
+                "sha256:60c783a7994246b2e710aa2f0a2f7fcfacf156cffc7b50f7074bfd97c9046db3"
             ],
-            "version": "==3.0.0"
+            "version": "==3.1.2"
         },
         "async-timeout": {
             "hashes": [
@@ -87,10 +87,10 @@
         },
         "defusedxml": {
             "hashes": [
-                "sha256:24d7f2f94f7f3cb6061acb215685e5125fbcdc40a857eff9de22518820b0a4f4",
-                "sha256:702a91ade2968a82beb0db1e0766a6a273f33d4616a6ce8cde475d8e09853b20"
+                "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
+                "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
             ],
-            "version": "==0.5.0"
+            "version": "==0.6.0"
         },
         "docopt": {
             "hashes": [
@@ -159,10 +159,10 @@
         },
         "jdcal": {
             "hashes": [
-                "sha256:948fb8d079e63b4be7a69dd5f0cd618a0a57e80753de8248fd786a8a20658a07",
-                "sha256:ea0a5067c5f0f50ad4c7bdc80abad3d976604f6fb026b0b3a17a9d84bb9046c9"
+                "sha256:1abf1305fce18b4e8aa248cf8fe0c56ce2032392bc64bbd61b5dff2a19ec8bba",
+                "sha256:472872e096eb8df219c23f2689fc336668bdb43d194094b5cc1707e1640acfc8"
             ],
-            "version": "==1.4"
+            "version": "==1.4.1"
         },
         "jinja2": {
             "hashes": [
@@ -306,10 +306,10 @@
         },
         "rfc3986": {
             "hashes": [
-                "sha256:5ad82677b02b88c8d24f6511b4ee9baa5e7da675599b479fbbc5c9c578b5b737",
-                "sha256:bc3ae4b7cd88a99eff2d3900fcb858d44562fd7f273fc07aeef568b9bb6fc4e1"
+                "sha256:2cb285760d8ed6683f9a242686961918d555f6783027d596cb82df51bfa0f9ca",
+                "sha256:a69146f5014a7da1fed9d375c99f5fe2782a27c0e75c778a4083fe954abbde42"
             ],
-            "version": "==1.2.0"
+            "version": "==1.3.1"
         },
         "rx": {
             "hashes": [
@@ -327,10 +327,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:d5432832f91d200c3d8b473a266d59442d825f9ea744c467e68c5d9a9479fbce"
+                "sha256:91c54ca8345008fceaec987e10924bf07dcab36c442925357e5a467b36a38319"
             ],
             "markers": "python_version >= '3.0'",
-            "version": "==1.3.2"
+            "version": "==1.3.3"
         },
         "sqlparse": {
             "hashes": [
@@ -360,16 +360,16 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
             ],
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         },
         "uvicorn": {
             "hashes": [
-                "sha256:d96fb442d9ce9c1dba67360035161d392970b8e6b0ed797d2cefed24abfd78bc"
+                "sha256:181d47abddedd0f6e23eaeed97976bdce9ea1dbff0ec12385309cf4835783f6a"
             ],
-            "version": "==0.7.0b2"
+            "version": "==0.7.0"
         },
         "uvloop": {
             "hashes": [
@@ -473,37 +473,37 @@
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:163d3ee445a0b4c0109877da9e46271aacf4e5e3d60ae7368669555c30f13e7c",
-                "sha256:1af0bfe7b0c13a0e613a27311fd4f9c5d024e8fc0f4b3d284e7df02a58a11fc0",
-                "sha256:2169c3a1bf52d5b30cc98625b5919a964c571a32e8646be20be6c7e3e82079de",
-                "sha256:218f079fa48e2ef812dc3d3ce6ec2f67ac56427ba4b038d5d6331f2cceb489c2",
-                "sha256:26a958930687e94c4c6c73c171e4d4783b82ae4e16aa3424e6bcd4529bceedf0",
-                "sha256:2c7c195aef3acdbc853942bc674844031a732890d2fee88a324298ed376b6c2b",
-                "sha256:2ecdbfed7004669472bfa27c8d51012c717c241c7154ae17e4c8f93024043525",
-                "sha256:345fc31b71a90ada1b51826537917b19a1af685a91c0f066787069c184d7d00f",
-                "sha256:378a06649503f548be5f1e9eec2e94cc1d6138250b82a08dcc6151bca8cec107",
-                "sha256:3f300bf2930e501dde09605de85cb2b84c2638e2c954be02a3c86f28176d3525",
-                "sha256:6c2f66c653ce8bbd7e789d0f7f92c3f9fea881b55226f0ae5ee550cce9e3cf0e",
-                "sha256:6fccbac2633831b877a8fbf865f7082d34895e82a015795a9f80f99a2efe2576",
-                "sha256:7a166f8ccb6888358d3e67795b057540ea7caa71ab9e089b0cb0097f01088965",
-                "sha256:8f6b84f887ec6fef6c1796779f8ec2603dc7e9ef52bc9269de719d4bcbdaebbb",
-                "sha256:92cf3ceb7bb90cf35b8bd993c640b15d4832ba0e142a3b9da5006ef217da595d",
-                "sha256:a20dfdf73f56da674926a3811929cff9fd23b9af90be9a6c36ac246a3486eef3",
-                "sha256:a84415df4689251556c961e4fe3b25d30e32f00faa8064ce0909458dbe0d67b2",
-                "sha256:ab1aa1cd50df3860f624c9713ee9e690eefd4e049d3a4d86577bab6e741e9616",
-                "sha256:abc9dcf85e75a8687f2a6d560c0c1a2593e8e34ba6f9ad6721f8212c5de179a2",
-                "sha256:c10454710a81a2f4b1ff4d1c83ac2cec63e0e55845a56324991514af5b1299d0",
-                "sha256:c38f80719e4dfae7a6311a4f091f07f4fb2fb5d602352015d5639f63f8fabb68",
-                "sha256:d75cf00605630b2cfefa5c62373c605dcda1cc0d607902847dbb8e8e9b67c1ce",
-                "sha256:dce15cb6ef604c9e38fdaa848f58f83153ade9f4aa5e4cf5812aa27163561750",
-                "sha256:e7e0db4311bb76bf3f6e0380f71912cfa6d0be7cc635e3772476050b0dabdabd",
-                "sha256:eac59cae78dfe3fbf7ece25c170d7a152f88df7643381aa5e7344c2028a8d8d4",
-                "sha256:ead7b3e1567bd14cacd44279c5e42cd19f54b9feed39180220253f4fbe3abd56",
-                "sha256:ed772a5e8e7e5dd6bede960a86940c17cf653c7f158dafa5d52e919b676f10ba",
-                "sha256:f2d73131acb94afa45de8b6b8a4bfb21bbe3736633d6478e53247f19dd8c299c"
+                "sha256:007ca0df127b1862fc010125bc4100b7a630efc6841047bd11afceadb4754611",
+                "sha256:03c49e02adf0b4d68f422fdbd98f7a7c547beb27e99a75ed02298f85cb48406a",
+                "sha256:0a1232cdd314e08848825edda06600455ad2a7adaa463ebfb12ece2d09f3370e",
+                "sha256:131c80d0958c89273d9720b9adf9df1d7600bb3120e16019a7389ab15b079af5",
+                "sha256:2de34cc3b775724623f86617d2601308083176a495f5b2efc2bbb0da154f483a",
+                "sha256:2eddc31500f73544a2a54123d4c4b249c3c711d31e64deddb0890982ea37397a",
+                "sha256:484f6c62bdc166ee0e5be3aa831120423bf399786d1f3b0304526c86180fbc0b",
+                "sha256:4c2d9369ed40b4a44a8ccd6bc3a7db6272b8314812d2d1091f95c4c836d92e06",
+                "sha256:70f570b5fa44413b9f30dbc053d17ef3ce6a4100147a10822f8662e58d473656",
+                "sha256:7a2b5b095f3bd733aab101c89c0e1a3f0dfb4ebdc26f6374805c086ffe29d5b2",
+                "sha256:804914a669186e2843c1f7fbe12b55aad1b36d40a28274abe6027deffad9433d",
+                "sha256:8520c03172da18345d012949a53617a963e0191ccb3c666f23276d5326af27b5",
+                "sha256:90da901fc33ea393fc644607e4a3916b509387e9339ec6ebc7bfded45b7a0ae9",
+                "sha256:a582416ad123291a82c300d1d872bdc4136d69ad0b41d57dc5ca3df7ef8e3088",
+                "sha256:ac8c5e20309f4989c296d62cac20ee456b69c41fd1bc03829e27de23b6fa9dd0",
+                "sha256:b2cf82f55a619879f8557fdaae5cec7a294fac815e0087c4f67026fdf5259844",
+                "sha256:b59d6f8cfca2983d8fdbe457bf95d2192f7b7efdb2b483bf5fa4e8981b04e8b2",
+                "sha256:be08168197021d669b9964bd87628fa88f910b1be31e7010901070f2540c05fd",
+                "sha256:be0f952f1c365061041bad16e27e224e29615d4eb1fb5b7e7760a1d3d12b90b6",
+                "sha256:c1c9a33e46d7c12b9c96cf2d4349d783e3127163fd96254dcd44663cf0a1d438",
+                "sha256:d18c89957ac57dd2a2724ecfe9a759912d776f96ecabba23acb9ecbf5c731035",
+                "sha256:d7e7b0ff21f39433c50397e60bf0995d078802c591ca3b8d99857ea18a7496ee",
+                "sha256:da0929b2bf0d1f365345e5eb940d8713c1d516312e010135b14402e2a3d2404d",
+                "sha256:de24a4962e361c512d3e528ded6c7480eab24c655b8ca1f0b761d3b3650d2f07",
+                "sha256:e45f93ff3f7dae2202248cf413a87aeb330821bf76998b3cf374eda2fc893dd7",
+                "sha256:f046aeae1f7a845041b8661bb7a52449202b6c5d3fb59eb4724e7ca088811904",
+                "sha256:f1dc2b7b2748084b890f5d05b65a47cd03188824890e9a60818721fd492249fb",
+                "sha256:fcbe7cf3a786572b73d2cd5f34ed452a5f5fac47c9c9d1e0642c457a148f9f88"
             ],
             "index": "pypi",
-            "version": "==2.8.1"
+            "version": "==2.8.2"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8f0d265330426fa308fed222495ba0df855e34f9266667f8cb6be6b9c16541de"
+            "sha256": "c4c3a200098890d00c6bc323ad6c8bd97719c7cdf0d53537f25b91baf80ae8c9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -57,12 +57,19 @@
             ],
             "version": "==3.0.1"
         },
+        "backports.csv": {
+            "hashes": [
+                "sha256:bed884eeb967c8d6f517dfcf672914324180f1e9ceeb0376fde2c4c32fd7008d",
+                "sha256:f68c7115c7fbe6d4b4104327d2e677efb38aa09bd7f877b47a6de18e44975510"
+            ],
+            "version": "==1.0.6"
+        },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -255,9 +262,19 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:0b83c5697aed17a27efbb631a6a3846501375c6e55112a665b210f223fa69629"
+                "sha256:544a0050e76e9b60751c58617fa28c253ad5d23af2e5f0b1c250390bf90bb0df",
+                "sha256:594bf80477a58b6fd53e8b3f24ccf965c25eeeb6e05e4b1fb18c82c2d2090603",
+                "sha256:75e20ca689d0a2bf0c84f0e2028cc68ebef34b213fa66d73c410c53f870c49f4",
+                "sha256:994da68a1dc1050f290f8017f044172360b608c0f2562b47645ecc69d7a61c0a",
+                "sha256:ad902e00088c50bdced94a57b819c24fdadaeaed5494df7a9a67d63774f210fd",
+                "sha256:b11aff75875ffc73541c4e4b1ac2f5e21717c1fc4396238943b9a44d962e74e1",
+                "sha256:bc733b5a9047c3e4848c0e80eeacfa6a799139242606410260c5450d665ea58c",
+                "sha256:d960c68931b96bb215f385baa8ef867b8ebac66af60fa06cc1008f963848c7ad",
+                "sha256:dd461c04e6a91e4eef7d5b75c1fc1c7013d3f8d354033b16526baadddd524079",
+                "sha256:e4d6b5d6218a06f3141189d75c93876dd525a6d15f1b00ef4f274726c93719f1",
+                "sha256:f3c386fa12415bde8a0162745c4badf98fe171c6dfd67e54831f05ec88feeebb"
             ],
-            "version": "==5.1b3"
+            "version": "==5.1b5"
         },
         "records": {
             "hashes": [
@@ -310,10 +327,18 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:7dede29f121071da9873e7b8c98091874617858e790dc364ffaab4b09d81216c"
+                "sha256:781fb7b9d194ed3fc596b8f0dd4623ff160e3e825dd8c15472376a438c19598b"
             ],
             "markers": "python_version >= '3.0'",
-            "version": "==1.3.0b3"
+            "version": "==1.3.1"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec",
+                "sha256:d9cf190f51cbb26da0412247dfe4fb5f4098edb73db84e02f9fc21fdca31fed4"
+            ],
+            "index": "pypi",
+            "version": "==0.2.4"
         },
         "starlette": {
             "hashes": [
@@ -323,15 +348,10 @@
         },
         "tablib": {
             "hashes": [
-                "sha256:b8cf50a61d66655229993f2ee29220553fb2c80403479f8e6de77c0c24649d87"
+                "sha256:0f88a9cebdaa1a2cc29ae57387082ee81015d1149ecd34e48a8c8d3b4dd21670",
+                "sha256:5f33c079b07eb10cf9c4b4696add2ecf32c89db7729240546ecdcd5c92f67e13"
             ],
-            "version": "==0.12.1"
-        },
-        "unicodecsv": {
-            "hashes": [
-                "sha256:018c08037d48649a0412063ff4eda26eaa81eff1546dbffa51fa5293276ff7fc"
-            ],
-            "version": "==0.14.1"
+            "version": "==0.13.0"
         },
         "urllib3": {
             "hashes": [
@@ -342,9 +362,9 @@
         },
         "uvicorn": {
             "hashes": [
-                "sha256:bda2225f673dffe7e3fd6223ebd22b010ab6e624a4e8cf4c4d380656c7eb264b"
+                "sha256:8d523d0a003a874245025295b0c1233a762402c0d4c3988017401c6b461c83e9"
             ],
-            "version": "==0.4.6"
+            "version": "==0.5.1"
         },
         "uvloop": {
             "hashes": [

--- a/nerium/__init__.py
+++ b/nerium/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
 from nerium.commit import get_commit_for_version
 from nerium.__version__ import __version__  # noqa F401
 

--- a/nerium/__version__.py
+++ b/nerium/__version__.py
@@ -1,3 +1,3 @@
 VERSION = (0, 5, 4)
 
-__version__ = '.'.join(map(str, VERSION))
+__version__ = ".".join(map(str, VERSION))

--- a/nerium/app.py
+++ b/nerium/app.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*
+
 from pathlib import Path
 
 import responder

--- a/nerium/app.py
+++ b/nerium/app.py
@@ -7,22 +7,23 @@ from nerium.utils import unwrap_querystring_lists
 
 # Provision environment as needed
 # Load local .env first
-load_dotenv(Path.cwd() / '.env')
+load_dotenv(Path.cwd() / ".env")
 # Load this one for use w/ Kubernetes secret mount
-load_dotenv('/dotenv/.env')
+load_dotenv("/dotenv/.env")
 
 api = responder.API(
     cors=True,
     cors_params={
-        'allow_credentials': True,
-        'expose_headers': ["*"],
-        'allow_headers': ["*"],
-        'allow_methods': ["*"]
+        "allow_credentials": True,
+        "expose_headers": ["*"],
+        "allow_headers": ["*"],
+        "allow_methods": ["*"],
     },
-    title='Nerium',
-    version='1.0',
-    openapi='3.0.0',
-    docs_route="/docs")
+    title="Nerium",
+    version="1.0",
+    openapi="3.0.0",
+    docs_route="/docs",
+)
 
 
 @api.route("/")
@@ -49,7 +50,7 @@ async def serve_report_description(req, resp, query_name):
 
 @api.route("/v1/results/{query_name}")
 @api.route("/v1/results/{query_name}/{format_}")
-async def serve_query_result(req, resp, *, query_name, format_='default'):
+async def serve_query_result(req, resp, *, query_name, format_="default"):
     params = unwrap_querystring_lists(req.params)
     query_results = query.get_result_set(query_name, **params)
     if query_results.error:
@@ -64,7 +65,7 @@ async def serve_query_result(req, resp, *, query_name, format_='default'):
 async def serve_csv_result(req, resp, *, query_name):
     params = unwrap_querystring_lists(req.params)
     query_results = query.results_to_csv(query_name, **params)
-    resp.headers = {'content_type': 'text/csv'}
+    resp.headers = {"content_type": "text/csv"}
     resp.content = query_results
 
 

--- a/nerium/commit.py
+++ b/nerium/commit.py
@@ -1,22 +1,21 @@
 import requests
-from requests.exceptions import ConnectionError
-
 from nerium import __version__
+from requests.exceptions import ConnectionError
 
 
 def get_commit_for_version(version=__version__):
-    v = f'v{version}'
+    v = f"v{version}"
 
     try:
-        resp = requests.get('https://api.github.com/repos/OAODEV/nerium/tags')
+        resp = requests.get("https://api.github.com/repos/OAODEV/nerium/tags")
         tags = resp.json()
-        vtag = list(filter(lambda t: v == t['name'], tags))
+        vtag = list(filter(lambda t: v == t["name"], tags))
         vtag = vtag[0]
-        commit_url = vtag['commit']['url']
+        commit_url = vtag["commit"]["url"]
         resp = requests.get(commit_url)
-        commit = resp.json()['url']
+        commit = resp.json()["url"]
     except (IndexError, KeyError, TypeError, ConnectionError, ValueError):
-        commit = 'Not found'
+        commit = "Not found"
     return commit
 
 

--- a/nerium/data_source.py
+++ b/nerium/data_source.py
@@ -17,6 +17,8 @@ def get_data_source(query):
     """
     # *** GET CONNECTION PARAMS: ***
     # from frontmatter
+    # TODO: try `database_url` key first, return as string if present
+    # TODO: factor out try/except block
     try:
         return query.metadata['data_source']
     except KeyError:

--- a/nerium/data_source.py
+++ b/nerium/data_source.py
@@ -20,26 +20,25 @@ def get_data_source(query):
     # TODO: try `database_url` key first, return as string if present
     # TODO: factor out try/except block
     try:
-        return query.metadata['data_source']
+        return query.metadata["data_source"]
     except KeyError:
         try:
-            return dict(url=query.metadata['database_url'])
+            return dict(url=query.metadata["database_url"])
         except KeyError:
             pass
 
     # from file in directory if present
-    db_file = query.path.parent / 'db.yaml'
+    db_file = query.path.parent / "db.yaml"
     if db_file.is_file():
-        with open(db_file, 'r') as dbf:
+        with open(db_file, "r") as dbf:
             db_meta = yaml.safe_load(dbf.read())
             try:
-                return db_meta['data_source']
+                return db_meta["data_source"]
             except KeyError:
                 try:
-                    return dict(url=db_meta['database_url'])
+                    return dict(url=db_meta["database_url"])
                 except KeyError:
                     pass
 
     # Use env['DATABASE_URL']/sqlite if nothing else is configured
-    return dict(
-        url=os.getenv('DATABASE_URL', 'sqlite:///'))
+    return dict(url=os.getenv("DATABASE_URL", "sqlite:///"))

--- a/nerium/discovery.py
+++ b/nerium/discovery.py
@@ -37,9 +37,9 @@ def columns_from_body(query):
     parsed_query = parse(query.body)[0]
     for tkn in parsed_query.tokens:
         if isinstance(tkn, IdentifierList):
-            for id in tkn:
-                if isinstance(id, Identifier):
-                    columns.append(id.get_name())
+            for id_ in tkn:
+                if isinstance(id_, Identifier):
+                    columns.append(id_.get_name())
     if not columns:
         columns = 'unknown'
     return columns

--- a/nerium/discovery.py
+++ b/nerium/discovery.py
@@ -1,0 +1,91 @@
+import re
+from types import SimpleNamespace
+
+from nerium.query import FLAT_QUERIES, get_query
+from sqlparse import parse
+from sqlparse.sql import IdentifierList, Identifier
+
+
+def list_reports():
+    """Return list of available report names from query dir
+    """
+    # Filter out docs and metadata
+    query_paths = list(
+        filter(lambda i: i.suffix not in ['.md', '.yaml'], FLAT_QUERIES))
+    query_names = [i.stem for i in query_paths]
+    query_names.sort()
+    reports = dict(reports=query_names)
+    return reports
+
+
+def columns_from_metadata(query):
+    """Return `columns` block from query front matter,
+    if present
+    """
+    columns = None
+    if 'columns' in query.metadata.keys():
+        columns = query.metadata['columns']
+    return columns
+
+
+def columns_from_body(query):
+    """Parse columns from SELECT statement
+    """
+    columns = []
+    if query.result_mod != 'sql':
+        columns = None
+    parsed_query = parse(query.body)[0]
+    for tkn in parsed_query.tokens:
+        if isinstance(tkn, IdentifierList):
+            for id in tkn:
+                if isinstance(id, Identifier):
+                    columns.append(id.get_name())
+    if not columns:
+        columns = 'unknown'
+    return columns
+
+
+def params_from_metadata(query):
+    params = None
+    if 'params' in query.metadata.keys():
+        params = query.metadata['params']
+    return params
+
+
+def params_from_body(query):
+    param_regex = re.compile('(?<!\\w)\\:\\w+')
+    param_list = [i.strip(':') for i in re.findall(param_regex, query.body)]
+    return param_list
+
+
+def get_report_query(query_name):
+    query = get_query(query_name)
+    if not query:
+        query = SimpleNamespace()
+        query.error = f"No query found matching '{query_name}'"
+        query.status_code = 404
+    return query
+
+
+def describe_report(query_name):
+    report_query = get_report_query(query_name)
+    if report_query.error:
+        return report_query
+    params = (params_from_metadata(report_query)
+              or params_from_body(report_query))
+    columns = (columns_from_metadata(report_query)
+               or columns_from_body(report_query))
+    report_description = SimpleNamespace(
+        error=report_query.error,
+        name=report_query.name,
+        type=report_query.result_mod,
+        columns=columns,
+        params=params,
+        metadata=report_query.metadata)
+    return report_description
+
+
+if __name__ == "__main__":
+    q = describe_report('foo')
+    # h = params_from_body(q)
+    print(q)

--- a/nerium/discovery.py
+++ b/nerium/discovery.py
@@ -10,8 +10,7 @@ def list_reports():
     """Return list of available report names from query dir
     """
     # Filter out docs and metadata
-    query_paths = list(
-        filter(lambda i: i.suffix not in ['.md', '.yaml'], FLAT_QUERIES))
+    query_paths = list(filter(lambda i: i.suffix not in [".md", ".yaml"], FLAT_QUERIES))
     query_names = [i.stem for i in query_paths]
     query_names.sort()
     reports = dict(reports=query_names)
@@ -23,8 +22,8 @@ def columns_from_metadata(query):
     if present
     """
     columns = None
-    if 'columns' in query.metadata.keys():
-        columns = query.metadata['columns']
+    if "columns" in query.metadata.keys():
+        columns = query.metadata["columns"]
     return columns
 
 
@@ -32,7 +31,7 @@ def columns_from_body(query):
     """Parse columns from SELECT statement
     """
     columns = []
-    if query.result_mod != 'sql':
+    if query.result_mod != "sql":
         columns = None
     parsed_query = parse(query.body)[0]
     for tkn in parsed_query.tokens:
@@ -41,20 +40,20 @@ def columns_from_body(query):
                 if isinstance(id_, Identifier):
                     columns.append(id_.get_name())
     if not columns:
-        columns = 'unknown'
+        columns = "unknown"
     return columns
 
 
 def params_from_metadata(query):
     params = None
-    if 'params' in query.metadata.keys():
-        params = query.metadata['params']
+    if "params" in query.metadata.keys():
+        params = query.metadata["params"]
     return params
 
 
 def params_from_body(query):
-    param_regex = re.compile('(?<!\\w)\\:\\w+')
-    param_list = [i.strip(':') for i in re.findall(param_regex, query.body)]
+    param_regex = re.compile("(?<!\\w)\\:\\w+")
+    param_list = [i.strip(":") for i in re.findall(param_regex, query.body)]
     return param_list
 
 
@@ -71,21 +70,20 @@ def describe_report(query_name):
     report_query = get_report_query(query_name)
     if report_query.error:
         return report_query
-    params = (params_from_metadata(report_query)
-              or params_from_body(report_query))
-    columns = (columns_from_metadata(report_query)
-               or columns_from_body(report_query))
+    params = params_from_metadata(report_query) or params_from_body(report_query)
+    columns = columns_from_metadata(report_query) or columns_from_body(report_query)
     report_description = SimpleNamespace(
         error=report_query.error,
         name=report_query.name,
         type=report_query.result_mod,
         columns=columns,
         params=params,
-        metadata=report_query.metadata)
+        metadata=report_query.metadata,
+    )
     return report_description
 
 
 if __name__ == "__main__":
-    q = describe_report('foo')
+    q = describe_report("foo")
     # h = params_from_body(q)
     print(q)

--- a/nerium/formatter.py
+++ b/nerium/formatter.py
@@ -6,16 +6,17 @@ from importlib import import_module
 def get_format(format_):
     """ Find format schema in $FORMAT_PATH or nerium/schema
     """
-    format_path = os.getenv('FORMAT_PATH', 'format_files')
+    format_path = os.getenv("FORMAT_PATH", "format_files")
     try:
         spec = importlib.util.spec_from_file_location(
-            "format_mod", f"{format_path}/{format_}.py")
+            "format_mod", f"{format_path}/{format_}.py"
+        )
         format_mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(format_mod)
     except FileNotFoundError:
         try:
-            format_mod = import_module(f'nerium.schema.{format_}')
+            format_mod = import_module(f"nerium.schema.{format_}")
         except ModuleNotFoundError:
-            format_mod = import_module('nerium.schema.default')
+            format_mod = import_module("nerium.schema.default")
     schema = format_mod.ResultSchema()
     return schema

--- a/nerium/query.py
+++ b/nerium/query.py
@@ -60,8 +60,9 @@ def get_result_set(query_name, **kwargs):
         query.status_code = 404
         return query
     try:
+        # TODO: Make this able to accept plugins from elsewhere
         result_mod = import_module(
-            f'nerium.contrib.resultset.{query.result_mod}')
+            f'nerium.resultset.{query.result_mod}')
     except ModuleNotFoundError:
         result_mod = import_module('nerium.resultset.sql')
     query.params = {**kwargs}
@@ -82,6 +83,7 @@ def get_result_set(query_name, **kwargs):
 def results_to_csv(query_name, **kwargs):
     """ Generate CSV from result data
     """
+    # TODO: separate module for this
     query = get_result_set(query_name, **kwargs)
     result = query.result
     columns = list(result[0].keys())

--- a/nerium/query.py
+++ b/nerium/query.py
@@ -19,15 +19,18 @@ FLAT_QUERIES = list(Path(os.getenv('QUERY_PATH', 'query_files')).glob('**/*'))
 def get_query(query_name):
     """Find file matching query_name, read and return query object
     """
+    # TODO: Sort out the multiple functions here, refactor to smaller/purer
     query_file_match = list(
         filter(lambda i: query_name == i.stem, FLAT_QUERIES))
     if not query_file_match:
         return None
     # TODO: Log warning if more than one match
+    #       Maybe include warning in response error attr
     query_file = query_file_match[0]
     with open(query_file) as f:
         metadata, query_body = frontmatter.parse(f.read())
     result_mod = query_file.suffix.strip('.')
+    # TODO: Use @dataclass here instead
     query_obj = SimpleNamespace(
         name=query_name,
         metadata=metadata,
@@ -49,6 +52,7 @@ def process_template(sql, **kwargs):
 def get_result_set(query_name, **kwargs):
     """ Call get_query, then submit query from file to resultset module
     """
+    # TODO: Can this be broken up as well?
     query = get_query(query_name)
     if not query:
         query = SimpleNamespace()

--- a/nerium/query.py
+++ b/nerium/query.py
@@ -13,15 +13,14 @@ from tablib.formats._json import serialize_objects_handler as handler
 # Walking the query_files dir to get all the queries in a single list
 # NOTE: this means query names should be unique across subdirectories,
 #       *and* adding a new query file requires restart
-FLAT_QUERIES = list(Path(os.getenv('QUERY_PATH', 'query_files')).glob('**/*'))
+FLAT_QUERIES = list(Path(os.getenv("QUERY_PATH", "query_files")).glob("**/*"))
 
 
 def get_query(query_name):
     """Find file matching query_name, read and return query object
     """
     # TODO: Sort out the multiple functions here, refactor to smaller/purer
-    query_file_match = list(
-        filter(lambda i: query_name == i.stem, FLAT_QUERIES))
+    query_file_match = list(filter(lambda i: query_name == i.stem, FLAT_QUERIES))
     if not query_file_match:
         return None
     # TODO: Log warning if more than one match
@@ -29,7 +28,7 @@ def get_query(query_name):
     query_file = query_file_match[0]
     with open(query_file) as f:
         metadata, query_body = frontmatter.parse(f.read())
-    result_mod = query_file.suffix.strip('.')
+    result_mod = query_file.suffix.strip(".")
     # TODO: Use @dataclass here instead
     query_obj = SimpleNamespace(
         name=query_name,
@@ -38,7 +37,8 @@ def get_query(query_name):
         result_mod=result_mod,
         body=query_body,
         error=False,
-        executed=datetime.utcnow().isoformat())
+        executed=datetime.utcnow().isoformat(),
+    )
     return query_obj
 
 
@@ -61,10 +61,9 @@ def get_result_set(query_name, **kwargs):
         return query
     try:
         # TODO: Make this able to accept plugins from elsewhere
-        result_mod = import_module(
-            f'nerium.resultset.{query.result_mod}')
+        result_mod = import_module(f"nerium.resultset.{query.result_mod}")
     except ModuleNotFoundError:
-        result_mod = import_module('nerium.resultset.sql')
+        result_mod = import_module("nerium.resultset.sql")
     query.params = {**kwargs}
     query.body = process_template(sql=query.body, **query.params)
     result = result_mod.result(query, **query.params)
@@ -72,8 +71,8 @@ def get_result_set(query_name, **kwargs):
     # serialization handling courtesy of `tablib`
     query.result = json.loads(json.dumps(result, default=handler))
     try:
-        if 'error' in query.result[0].keys():
-            query.error = query.result[0]['error']
+        if "error" in query.result[0].keys():
+            query.error = query.result[0]["error"]
             query.status_code = 400
     except IndexError:
         pass
@@ -92,5 +91,5 @@ def results_to_csv(query_name, **kwargs):
     frame.headers = columns
     for row in data:
         frame.append(row)
-    csvs = frame.export('csv')
+    csvs = frame.export("csv")
     return csvs

--- a/nerium/resultset/sql.py
+++ b/nerium/resultset/sql.py
@@ -14,7 +14,9 @@ def connection(query):
 
 def result(query, **kwargs):
     try:
-        rows = connection(query).query(query.body, **kwargs)
+        db = connection(query)
+        sql = query.body
+        rows = db.query(sql, **kwargs)
         rows = rows.as_dict()
     except Exception as e:
         rows = [{'error': repr(e)}, ]  # yapf: disable

--- a/nerium/resultset/sql.py
+++ b/nerium/resultset/sql.py
@@ -7,7 +7,7 @@ from nerium import data_source
 
 
 def connection(query):
-    db_url = data_source.get_data_source(query)['url']
+    db_url = data_source.get_data_source(query)["url"]
     db = records.Database(db_url)
     return db
 
@@ -19,5 +19,5 @@ def result(query, **kwargs):
         rows = db.query(sql, **kwargs)
         rows = rows.as_dict()
     except Exception as e:
-        rows = [{'error': repr(e)}, ]  # yapf: disable
+        rows = [{"error": repr(e)}]
     return rows

--- a/nerium/schema/compact.py
+++ b/nerium/schema/compact.py
@@ -6,5 +6,4 @@ from nerium.app import api
 @api.schema("Compact")
 class ResultSchema(Schema):
     columns = fields.Function(lambda obj: list(obj.result[0].keys()))
-    data = fields.Function(
-        lambda obj: [tuple(row.values()) for row in obj.result])
+    data = fields.Function(lambda obj: [tuple(row.values()) for row in obj.result])

--- a/nerium/schema/default.py
+++ b/nerium/schema/default.py
@@ -5,8 +5,8 @@ from nerium.app import api
 
 @api.schema("Default")
 class ResultSchema(Schema):
-    name = fields.Str(attribute='name')
-    data = fields.List(fields.Dict(), attribute='result')
+    name = fields.Str(attribute="name")
+    data = fields.List(fields.Dict(), attribute="result")
     metadata = fields.Dict()
     params = fields.Dict()
     error = fields.Str()

--- a/nerium/utils.py
+++ b/nerium/utils.py
@@ -3,8 +3,6 @@ def unwrap_querystring_lists(obj):
     if there's only one.
     """
     new_dict = {
-        key: (obj[key][0]
-              if len(obj[key]) == 1 else obj[key])
-        for key in obj.keys()
-        }
+        key: (obj[key][0] if len(obj[key]) == 1 else obj[key]) for key in obj.keys()
+    }
     return new_dict

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'python-dotenv', 'python-frontmatter', 'pyyaml', 'records', 'responder'
+    'python-dotenv', 'python-frontmatter', 'pyyaml', 'records', 'responder',
+    'sqlparse'
 ]
 
 # What packages are optional?

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,11 @@ AUTHOR = 'Thomas Yager-Madden'
 REQUIRES_PYTHON = '>=3.6.0'
 VERSION = None
 
-# What packages are required for this module to be executed?
 REQUIRED = [
     'python-dotenv', 'python-frontmatter', 'pyyaml', 'records', 'responder',
     'sqlparse'
 ]
 
-# What packages are optional?
 EXTRAS = {
     'mysql': ['PyMySQL'],
     'pg': ['psycopg2'],
@@ -112,8 +110,6 @@ setup(
     include_package_data=True,
     license='Apache License, Version 2.0',
     classifiers=[
-        # Trove classifiers
-        # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -9,25 +9,26 @@ from shutil import rmtree
 from setuptools import find_packages, setup, Command
 
 # Package meta-data.
-NAME = 'Nerium'
-DESCRIPTION = 'The little business intelligence engine that could.'
-URL = 'https://github.com/tym-xqo/nerium'
-EMAIL = 'yagermadden@gmail.com'
-AUTHOR = 'Thomas Yager-Madden'
-REQUIRES_PYTHON = '>=3.6.0'
+NAME = "Nerium"
+DESCRIPTION = "The little business intelligence engine that could."
+URL = "https://github.com/tym-xqo/nerium"
+EMAIL = "yagermadden@gmail.com"
+AUTHOR = "Thomas Yager-Madden"
+REQUIRES_PYTHON = ">=3.6.0"
 VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'python-dotenv', 'python-frontmatter', 'pyyaml', 'records', 'responder',
-    'sqlparse'
+    "python-dotenv",
+    "python-frontmatter",
+    "pyyaml",
+    "records",
+    "responder",
+    "sqlparse",
 ]
 
 # What packages are optional?
-EXTRAS = {
-    'mysql': ['PyMySQL'],
-    'pg': ['psycopg2'],
-}
+EXTRAS = {"mysql": ["PyMySQL"], "pg": ["psycopg2"]}
 
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------
@@ -37,8 +38,8 @@ here = os.path.abspath(os.path.dirname(__file__))
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
 try:
-    with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
-        long_description = '\n' + f.read()
+    with io.open(os.path.join(here, "README.md"), encoding="utf-8") as f:
+        long_description = "\n" + f.read()
 except FileNotFoundError:
     long_description = DESCRIPTION
 
@@ -46,22 +47,22 @@ except FileNotFoundError:
 about = {}
 if not VERSION:
     project_slug = NAME.lower().replace("-", "_").replace(" ", "_")
-    with open(os.path.join(here, project_slug, '__version__.py')) as f:
+    with open(os.path.join(here, project_slug, "__version__.py")) as f:
         exec(f.read(), about)
 else:
-    about['__version__'] = VERSION
+    about["__version__"] = VERSION
 
 
 class UploadCommand(Command):
     """Support setup.py upload."""
 
-    description = 'Build and publish the package.'
+    description = "Build and publish the package."
     user_options = []
 
     @staticmethod
     def status(s):
         """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(s))
+        print("\033[1m{0}\033[0m".format(s))
 
     def initialize_options(self):
         pass
@@ -71,21 +72,20 @@ class UploadCommand(Command):
 
     def run(self):
         try:
-            self.status('Removing previous builds…')
-            rmtree(os.path.join(here, 'dist'))
+            self.status("Removing previous builds…")
+            rmtree(os.path.join(here, "dist"))
         except OSError:
             pass
 
-        self.status('Building Source and Wheel (universal) distribution…')
-        os.system('{0} setup.py sdist bdist_wheel --universal'.format(
-            sys.executable))
+        self.status("Building Source and Wheel (universal) distribution…")
+        os.system("{0} setup.py sdist bdist_wheel --universal".format(sys.executable))
 
-        self.status('Uploading the package to PyPI via Twine…')
-        os.system('twine upload dist/*')
+        self.status("Uploading the package to PyPI via Twine…")
+        os.system("twine upload dist/*")
 
-        self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(about['__version__']))
-        os.system('git push --tags')
+        self.status("Pushing git tags…")
+        os.system("git tag v{0}".format(about["__version__"]))
+        os.system("git push --tags")
 
         sys.exit()
 
@@ -93,42 +93,38 @@ class UploadCommand(Command):
 # Where the magic happens:
 setup(
     name=NAME,
-    version=about['__version__'],
+    version=about["__version__"],
     description=DESCRIPTION,
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author=AUTHOR,
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    packages=find_packages(exclude=('tests', )),
-    test_suite='tests',
+    packages=find_packages(exclude=("tests",)),
+    test_suite="tests",
     # TODO: A more sophisticated runserver CLI
-    entry_points={'console_scripts': [
-        'nerium = nerium.app:main',
-    ]},
+    entry_points={"console_scripts": ["nerium = nerium.app:main"]},
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     include_package_data=True,
-    license='Apache License, Version 2.0',
+    license="Apache License, Version 2.0",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-        'Environment :: Web Environment',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Topic :: Database :: Front-Ends',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: Utilities'
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "Environment :: Web Environment",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Database :: Front-Ends",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Utilities",
     ],
     # $ setup.py publish support.
-    cmdclass={
-        'upload': UploadCommand,
-    },
+    cmdclass={"upload": UploadCommand},
 )

--- a/tests/query/db.yaml
+++ b/tests/query/db.yaml
@@ -1,0 +1,1 @@
+database_url: sqlite:///

--- a/tests/query/db.yaml
+++ b/tests/query/db.yaml
@@ -1,1 +1,0 @@
-database_url: sqlite:///

--- a/tests/query/test.sql
+++ b/tests/query/test.sql
@@ -1,6 +1,9 @@
+---
+foo: bar
+---
 select cast(1.25 as float) as foo  -- float check
         -- timestamp check
-        , strftime('%Y-%m-%d', '2017-09-09') as bar
+        , strftime('%Y-%m-%d', '2019-09-09') as bar
         , 'Hello' as quux  -- ascii string check
         , 'Björk Guðmundsdóttir' as quuux  -- unicode check
     union

--- a/tests/test.py
+++ b/tests/test.py
@@ -56,7 +56,7 @@ class TestQueryResults(unittest.TestCase):
 class TestEndpointMessages(unittest.TestCase):
     def test_health_check(self):
         resp = api().requests.get(url='/v1')
-        assert resp.status_code == 200
+        self.assertEqual(resp.status_code, 200)
         text = resp.text
         self.assertIn("ok", text)
         self.assertIn("commit", text)
@@ -64,19 +64,19 @@ class TestEndpointMessages(unittest.TestCase):
     def test_sql_error(self):
         url = "/v1/results/error_test"
         resp = api().requests.get(url=url)
-        assert resp.status_code == 400
+        self.assertEqual(resp.status_code, 400)
         self.assertIn('error', resp.json())
 
     def test_missing_query_error(self):
         url = '/v1/results/not_a_query'
         resp = api().requests.get(url=url)
-        assert resp.status_code == 404
+        self.assertEqual(resp.status_code, 404)
         self.assertIn('error', resp.json())
 
     def test_missing_report_error(self):
         url = '/v1/reports/not_a_query'
         resp = api().requests.get(url=url)
-        assert resp.status_code == 404
+        self.assertEqual(resp.status_code, 404)
         self.assertIn('error', resp.json())
 
 
@@ -84,7 +84,7 @@ class TestResultsEndpoint(unittest.TestCase):
     def test_get_query(self):
         url = f"/v1/results/{query_name}"
         resp = api().requests.get(url=url)
-        assert resp.status_code == 200
+        self.assertEqual(resp.status_code, 200)
         self.assertEqual(EXPECTED, resp.json()['data'])
 
     def test_results_csv(self):
@@ -96,7 +96,7 @@ class TestResultsEndpoint(unittest.TestCase):
     def test_results_compact(self):
         url = f"/v1/results/{query_name}/compact"
         resp = api().requests.get(url=url)
-        assert resp.status_code == 200
+        self.assertEqual(resp.status_code, 200)
         self.assertEqual(
             COMPACT_EXPECTED, resp.json())
 
@@ -105,13 +105,13 @@ class TestReportsEndpoint(unittest.TestCase):
     def test_reports_list(self):
         url = "/v1/reports/list"
         resp = api().requests.get(url=url)
-        assert resp.status_code == 200
+        self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {'reports': ['error_test', 'test']})
 
     def test_report_descr(self):
         url = f"/v1/reports/{query_name}"
         resp = api().requests.get(url=url)
-        assert resp.status_code == 200
+        self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), DESCR_EXPECTED)
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -8,7 +8,7 @@ from nerium import app, query
 # Fixtures
 EXPECTED = [{
     'foo': 1.25,
-    'bar': '2017-09-09',
+    'bar': '2019-09-09',
     'quux': 'Hello',
     'quuux': 'Björk Guðmundsdóttir'
 }, {
@@ -18,18 +18,33 @@ EXPECTED = [{
     'quuux': 'ƺƺƺƺ'
 }]
 
-CSV_EXPECTED = 'foo,bar,quux,quuux\r\n1.25,2017-09-09,Hello,Björk Guðmundsdóttir\r\n42,2031-05-25,yo,ƺƺƺƺ\r\n'  # noqa E501
+CSV_EXPECTED = 'foo,bar,quux,quuux\r\n1.25,2019-09-09,Hello,Björk Guðmundsdóttir\r\n42,2031-05-25,yo,ƺƺƺƺ\r\n'  # noqa E501
 
 COMPACT_EXPECTED = {
     'columns': ['foo', 'bar', 'quux', 'quuux'],
-    'data': [[1.25, '2017-09-09', 'Hello', 'Björk Guðmundsdóttir'],
+    'data': [[1.25, '2019-09-09', 'Hello', 'Björk Guðmundsdóttir'],
              [42, '2031-05-25', 'yo', 'ƺƺƺƺ']]
+}
+
+DESCR_EXPECTED = {
+    "columns": ["foo", "bar", "quux", "quuux"],
+    "error": False,
+    "metadata": {
+        "foo": "bar"
+    },
+    "name": "test",
+    "params": [],
+    "type": "sql"
 }
 
 query_name = 'test'
 
 
-class TestResults(unittest.TestCase):
+def api():
+    return app.api
+
+
+class TestQueryResults(unittest.TestCase):
     query_path = Path(__file__).resolve().parent / 'query'
     os.environ['QUERY_PATH'] = str(query_path)
 
@@ -38,49 +53,66 @@ class TestResults(unittest.TestCase):
         self.assertEqual(result.result, EXPECTED)
 
 
-class TestAPI(unittest.TestCase):
-    def api(self):
-        return app.api
-
-    # def test_response(self):
+class TestEndpointMessages(unittest.TestCase):
     def test_health_check(self):
-        resp = self.api().requests.get(url='/v1')
+        resp = api().requests.get(url='/v1')
         assert resp.status_code == 200
         text = resp.text
         self.assertIn("ok", text)
         self.assertIn("commit", text)
 
-    def test_get_query(self):
-        url = "/v1/test"
-        resp = self.api().requests.get(url=url)
-        assert resp.status_code == 200
-        self.assertEqual(EXPECTED, resp.json()['data'])
-
-    def test_results_csv(self):
-        url = f"/v1/{query_name}/csv"
-        resp = self.api().requests.get(url=url)
-        assert resp.headers['content_type'] == 'text/csv'
-        # formatted_results = query.formatted_results(result, format_='csv')
-        self.assertEqual(resp.text, CSV_EXPECTED)
-
-    def test_results_compact(self):
-        url = f"/v1/{query_name}/compact"
-        resp = self.api().requests.get(url=url)
-        assert resp.status_code == 200
-        self.assertEqual(
-            COMPACT_EXPECTED, resp.json())
-
     def test_sql_error(self):
-        url = "/v1/error_test"
-        resp = self.api().requests.get(url=url)
+        url = "/v1/results/error_test"
+        resp = api().requests.get(url=url)
         assert resp.status_code == 400
         self.assertIn('error', resp.json())
 
     def test_missing_query_error(self):
-        url = '/v1/not_a_query'
-        resp = self.api().requests.get(url=url)
-        assert resp.status_code == 400
+        url = '/v1/results/not_a_query'
+        resp = api().requests.get(url=url)
+        assert resp.status_code == 404
         self.assertIn('error', resp.json())
+
+    def test_missing_report_error(self):
+        url = '/v1/reports/not_a_query'
+        resp = api().requests.get(url=url)
+        assert resp.status_code == 404
+        self.assertIn('error', resp.json())
+
+
+class TestResultsEndpoint(unittest.TestCase):
+    def test_get_query(self):
+        url = f"/v1/results/{query_name}"
+        resp = api().requests.get(url=url)
+        assert resp.status_code == 200
+        self.assertEqual(EXPECTED, resp.json()['data'])
+
+    def test_results_csv(self):
+        url = f"/v1/results/{query_name}/csv"
+        resp = api().requests.get(url=url)
+        assert resp.headers['content_type'] == 'text/csv'
+        self.assertEqual(resp.text, CSV_EXPECTED)
+
+    def test_results_compact(self):
+        url = f"/v1/results/{query_name}/compact"
+        resp = api().requests.get(url=url)
+        assert resp.status_code == 200
+        self.assertEqual(
+            COMPACT_EXPECTED, resp.json())
+
+
+class TestReportsEndpoint(unittest.TestCase):
+    def test_reports_list(self):
+        url = "/v1/reports/list"
+        resp = api().requests.get(url=url)
+        assert resp.status_code == 200
+        self.assertEqual(resp.json(), {'reports': ['error_test', 'test']})
+
+    def test_report_descr(self):
+        url = f"/v1/reports/{query_name}"
+        resp = api().requests.get(url=url)
+        assert resp.status_code == 200
+        self.assertEqual(resp.json(), DESCR_EXPECTED)
 
 
 if __name__ == '__main__':

--- a/tests/test.py
+++ b/tests/test.py
@@ -2,42 +2,39 @@ import os
 import unittest
 from pathlib import Path
 
-# from munch import unmunchify
 from nerium import app, query
 
 # Fixtures
-EXPECTED = [{
-    'foo': 1.25,
-    'bar': '2019-09-09',
-    'quux': 'Hello',
-    'quuux': 'Björk Guðmundsdóttir'
-}, {
-    'foo': 42,
-    'bar': '2031-05-25',
-    'quux': 'yo',
-    'quuux': 'ƺƺƺƺ'
-}]
+EXPECTED = [
+    {
+        "foo": 1.25,
+        "bar": "2019-09-09",
+        "quux": "Hello",
+        "quuux": "Björk Guðmundsdóttir",
+    },
+    {"foo": 42, "bar": "2031-05-25", "quux": "yo", "quuux": "ƺƺƺƺ"},
+]
 
-CSV_EXPECTED = 'foo,bar,quux,quuux\r\n1.25,2019-09-09,Hello,Björk Guðmundsdóttir\r\n42,2031-05-25,yo,ƺƺƺƺ\r\n'  # noqa E501
+CSV_EXPECTED = "foo,bar,quux,quuux\r\n1.25,2019-09-09,Hello,Björk Guðmundsdóttir\r\n42,2031-05-25,yo,ƺƺƺƺ\r\n"  # noqa E501
 
 COMPACT_EXPECTED = {
-    'columns': ['foo', 'bar', 'quux', 'quuux'],
-    'data': [[1.25, '2019-09-09', 'Hello', 'Björk Guðmundsdóttir'],
-             [42, '2031-05-25', 'yo', 'ƺƺƺƺ']]
+    "columns": ["foo", "bar", "quux", "quuux"],
+    "data": [
+        [1.25, "2019-09-09", "Hello", "Björk Guðmundsdóttir"],
+        [42, "2031-05-25", "yo", "ƺƺƺƺ"],
+    ],
 }
 
 DESCR_EXPECTED = {
     "columns": ["foo", "bar", "quux", "quuux"],
     "error": False,
-    "metadata": {
-        "foo": "bar"
-    },
+    "metadata": {"foo": "bar"},
     "name": "test",
     "params": [],
-    "type": "sql"
+    "type": "sql",
 }
 
-query_name = 'test'
+query_name = "test"
 
 
 def api():
@@ -45,8 +42,8 @@ def api():
 
 
 class TestQueryResults(unittest.TestCase):
-    query_path = Path(__file__).resolve().parent / 'query'
-    os.environ['QUERY_PATH'] = str(query_path)
+    query_path = Path(__file__).resolve().parent / "query"
+    os.environ["QUERY_PATH"] = str(query_path)
 
     def test_results_expected(self):
         result = query.get_result_set(query_name)
@@ -55,7 +52,7 @@ class TestQueryResults(unittest.TestCase):
 
 class TestEndpointMessages(unittest.TestCase):
     def test_health_check(self):
-        resp = api().requests.get(url='/v1')
+        resp = api().requests.get(url="/v1")
         self.assertEqual(resp.status_code, 200)
         text = resp.text
         self.assertIn("ok", text)
@@ -65,19 +62,19 @@ class TestEndpointMessages(unittest.TestCase):
         url = "/v1/results/error_test"
         resp = api().requests.get(url=url)
         self.assertEqual(resp.status_code, 400)
-        self.assertIn('error', resp.json())
+        self.assertIn("error", resp.json())
 
     def test_missing_query_error(self):
-        url = '/v1/results/not_a_query'
+        url = "/v1/results/not_a_query"
         resp = api().requests.get(url=url)
         self.assertEqual(resp.status_code, 404)
-        self.assertIn('error', resp.json())
+        self.assertIn("error", resp.json())
 
     def test_missing_report_error(self):
-        url = '/v1/reports/not_a_query'
+        url = "/v1/reports/not_a_query"
         resp = api().requests.get(url=url)
         self.assertEqual(resp.status_code, 404)
-        self.assertIn('error', resp.json())
+        self.assertIn("error", resp.json())
 
 
 class TestResultsEndpoint(unittest.TestCase):
@@ -85,20 +82,19 @@ class TestResultsEndpoint(unittest.TestCase):
         url = f"/v1/results/{query_name}"
         resp = api().requests.get(url=url)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(EXPECTED, resp.json()['data'])
+        self.assertEqual(EXPECTED, resp.json()["data"])
 
     def test_results_csv(self):
         url = f"/v1/results/{query_name}/csv"
         resp = api().requests.get(url=url)
-        assert resp.headers['content_type'] == 'text/csv'
+        assert resp.headers["content_type"] == "text/csv"
         self.assertEqual(resp.text, CSV_EXPECTED)
 
     def test_results_compact(self):
         url = f"/v1/results/{query_name}/compact"
         resp = api().requests.get(url=url)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(
-            COMPACT_EXPECTED, resp.json())
+        self.assertEqual(COMPACT_EXPECTED, resp.json())
 
 
 class TestReportsEndpoint(unittest.TestCase):
@@ -106,7 +102,7 @@ class TestReportsEndpoint(unittest.TestCase):
         url = "/v1/reports/list"
         resp = api().requests.get(url=url)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json(), {'reports': ['error_test', 'test']})
+        self.assertEqual(resp.json(), {"reports": ["error_test", "test"]})
 
     def test_report_descr(self):
         url = f"/v1/reports/{query_name}"
@@ -115,5 +111,5 @@ class TestReportsEndpoint(unittest.TestCase):
         self.assertEqual(resp.json(), DESCR_EXPECTED)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,4 +1,4 @@
 import os
 
-os.environ['DATABASE_URL'] = 'sqlite:///'
-os.environ['QUERY_PATH'] = 'tests/query/'
+os.environ["DATABASE_URL"] = "sqlite:///"
+os.environ["QUERY_PATH"] = "tests/query/"


### PR DESCRIPTION
- Moves previous "main" API endpoints under `/v1/results/`
- List of available reports by name at `/v1/reports`
- Descriptive metadata about report at `/v1/reports/<query_name>`
- Rearranged tests a bit, while adding tests for the new endpoints