### PR TITLE
Consolidate API routes and add S3 query file storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,18 @@
+# DATABASE_URL is the only required config setting
 DATABASE_URL=engine://nerium_user@localhost:port/database
+
+# Remainder are optional
+# ========
+# Path to directory where Nerium can find query files
+# Can be a local directory, or URL to S3 bucket with s3:// protocol scheme
 QUERY_PATH=/app/query_files
+# Path to local directory with marshmallow files, if using custom formats
 FORMAT_PATH=/app/format_files
-FLASK_ENV=development
-FLASK_APP=nerium/app.py
+# Set API_KEY to require X-API-Key header from all requests
 API_KEY=super-secret-key-value
+FLASK_APP=nerium/app.py
+FLASK_ENV=development
+
+# Set boto variables for authentication if using S3 for QUERY_PATH
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=

--- a/README.md
+++ b/README.md
@@ -131,49 +131,14 @@ For serialization formats besides the built-in default and `compact`, schema def
 
 ## API
 
-### Report listing endpoint
-
-#### URLs
-
-- `/v2/reports`
-
-#### Method
-
-`GET`
-
-#### Success Response
-
-**Code**: 200
-
-**Content**: `{"reports": [<an array of report names>]}`
-
-### Report description endpoints
-
-#### URLs
-
-- `/v2/reports/{string:query_name}`
-
-#### Method
-
-`GET`
-
-#### Success Response
-
-`{"columns":[<list of columns from report>],"error":false,"metadata":{<report: metadata object>},"name":"<query_name>","params":[<array of parameterized keys in query>],"type":"sql"}`
-
 ### Results endpoints
 
 #### URLs
 
 - `/v1/<string:query_name>?<query_params>`  
 - `/v1/<string:query_name>/<string:format>?<query_params>`
-- `/v2/results/`
-- `/v2/results/<string:query_name>?<query_params>`  
-- `/v2/results/<string:query_name>/<string:format>?<query_params>`
 
-[`v1` endpoints are deprecated and will be removed eventually]
-
-As shown above `query_name` and `format` may be accessed as part of the URL structure, or can be passed as parameters to the request.
+As shown above, `query_name` and `format` may be accessed as part of the URL structure, or can be passed as parameters to the request.
 
 Because we're retrieving report results here, the request is a `GET` in any case, but parameters may be sent in a JSON body or as querystring parameters. Note that `query_name` and `format` from URL base path will be preferred, even if a request to such a path happens to include either key in the request body (client apps should avoid doing this to avoid confusion).
 
@@ -204,6 +169,39 @@ Of course, it is possible that a database query might return no results. In this
 **Code**: 400
 
 **Content**: `{"error": <exception.repr from Python>}`
+
+### Documentation endpoints
+
+#### Report listing endpoint
+
+##### URLs
+
+- `/v1/docs/`
+
+##### Method
+
+`GET`
+
+##### Success Response
+
+**Code**: 200
+
+**Content**: `{"reports": [<an array of report names>]}`
+
+#### Report description endpoints
+
+##### URLs
+
+- `/v1/{string:query_name}/docs/`
+
+##### Method
+
+`GET`
+
+##### Success Response
+
+`{"columns":[<list of columns from report>],"error":false,"metadata":{<report: metadata object>},"name":"<query_name>","params":[<array of parameterized keys in query>],"type":"sql"}`
+
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Then add a `query_files` (and, optionally, `format_files`) directory to your pro
 
 By default, Nerium looks for query and format schema files in `query_files` and `format_files` respectively, in the current working directory from which the service is launched. `QUERY_PATH` and `FORMAT_PATH` environment variables can optionally be set in order to use files from other locations on the filesystem, as desired.
 
+#### Read SQL queries from S3
+
+If desired, instead of the local filesystem, Nerium can read its query files from an S3 bucket using [s3fs](https://s3fs.readthedocs.io/en/latest/). When Nerium is running as a remote service, a cloud storage bucket can provide a convenient shared location for report analysts to upload SQL to, so that reports can be enhanced or additional reports without having to restart or redeploy Nerium.
+
+Simply set the `QUERY_PATH` to your S3 bucket. Nerium looks for paths beginning with the `s3://` scheme, and reads from there when it finds one. Authentication to S3 is handled via [boto environment variables](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables).
+
+[S3-compatible storage that does not use URLs beginning with `s3://` is not supported. Neither is reading marshmallow format files from S3. Both may be coming in a later release.]
+
 ### Multiple Data Sources
 
 If you want to query multiple databases from a single Nerium installation, any individual query file can define its own `database_url` as a key in YAML front matter (see below). This will override the `$DATABASE_URL` setting in the environment for that query only. If you have a large number of queries across several databases, keep in mind that running a separate Nerium instance for each database could be an option.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ By default, Nerium looks for query and format schema files in `query_files` and 
 
 If desired, instead of the local filesystem, Nerium can read its query files from an S3 bucket using [s3fs](https://s3fs.readthedocs.io/en/latest/). When Nerium is running as a remote service, a cloud storage bucket can provide a convenient shared location for report analysts to upload SQL to, so that reports can be enhanced or additional reports without having to restart or redeploy Nerium.
 
-Simply set the `QUERY_PATH` to your S3 bucket. Nerium looks for paths beginning with the `s3://` scheme, and reads from there when it finds one. Authentication to S3 is handled via [boto environment variables](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables).
+Simply set the `QUERY_PATH` to your S3 bucket URL. Nerium looks for paths beginning with the `s3://` scheme, and reads from there when it finds one. Authentication to S3 is handled via [boto environment variables](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables).
 
 [S3-compatible storage that does not use URLs beginning with `s3://` is not supported. Neither is reading marshmallow format files from S3. Both may be coming in a later release.]
 

--- a/nerium/__version__.py
+++ b/nerium/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 11, 0)
+VERSION = (0, 12, 0)
 
 __version__ = ".".join(map(str, VERSION))

--- a/nerium/app.py
+++ b/nerium/app.py
@@ -16,29 +16,10 @@ CORS(app)
 
 @app.route("/")
 @app.route("/v1/")
-@app.route("/v2/")
 @require_api_key
 def base_route():
     """Health check route; returns OK with version and git commit detail"""
     return jsonify({"status": "ok", "version": __version__, "commit": commit})
-
-
-@app.route("/v2/reports/")
-@require_api_key
-def serve_report_list():
-    """Discovery route; returns a list of available reports known to the service"""
-    return jsonify(discovery.list_reports())
-
-
-@app.route("/v2/reports/<query_name>/")
-@require_api_key
-def serve_report_description(query_name):
-    """Discovery route; returns details and metadata about a report by name"""
-    report_descr = discovery.describe_report(query_name)
-    if report_descr.error:
-        status_code = getattr(report_descr, "status_code", 400)
-        return jsonify(dict(error=report_descr.error)), status_code
-    return jsonify(vars(report_descr))
 
 
 class ResultRequestSchema(Schema):
@@ -83,9 +64,6 @@ def get_query_result(params):
 
 @app.route("/v1/<query_name>/")
 @app.route("/v1/<query_name>/<format_>")
-@app.route("/v2/results")
-@app.route("/v2/results/<query_name>/")
-@app.route("/v2/results/<query_name>/<format_>")
 @require_api_key
 def serve_query_result(query_name="", format_=""):
     """Parse request and hand params to get_query_result"""
@@ -113,3 +91,21 @@ def serve_csv_result(query_name):
     resp.headers["content_type"] = "text/csv"
     resp.data = query_results
     return resp
+
+
+@app.route("/v1/docs/")
+@require_api_key
+def serve_report_list():
+    """Discovery route; returns a list of available reports known to the service"""
+    return jsonify(discovery.list_reports())
+
+
+@app.route("/v1/<query_name>/docs/")
+@require_api_key
+def serve_report_description(query_name):
+    """Discovery route; returns details and metadata about a report by name"""
+    report_descr = discovery.describe_report(query_name)
+    if report_descr.error:
+        status_code = getattr(report_descr, "status_code", 400)
+        return jsonify(dict(error=report_descr.error)), status_code
+    return jsonify(vars(report_descr))

--- a/nerium/app.py
+++ b/nerium/app.py
@@ -14,14 +14,6 @@ app.url_map.strict_slashes = False
 CORS(app)
 
 
-@app.route("/")
-@app.route("/v1/")
-@require_api_key
-def base_route():
-    """Health check route; returns OK with version and git commit detail"""
-    return jsonify({"status": "ok", "version": __version__, "commit": commit})
-
-
 class ResultRequestSchema(Schema):
     """Require query_name in valid results request, set format to "default" if
     not supplied
@@ -62,6 +54,8 @@ def get_query_result(params):
     return (formatted, 200)
 
 
+@app.route("/")
+@app.route("/v1/")
 @app.route("/v1/<query_name>/")
 @app.route("/v1/<query_name>/<format_>")
 @require_api_key
@@ -72,6 +66,11 @@ def serve_query_result(query_name="", format_=""):
         params["query_name"] = query_name
     if format_:
         params["format_"] = format_
+
+    if "query_name" not in params.keys():
+        # If no query_name is in request, treat as heath check;
+        # returns OK with version and git commit detail"""
+        return jsonify({"status": "ok", "version": __version__, "commit": commit})
 
     query_result = get_query_result(params)
 

--- a/nerium/discovery.py
+++ b/nerium/discovery.py
@@ -1,4 +1,3 @@
-import os
 import re
 from pathlib import Path
 

--- a/nerium/discovery.py
+++ b/nerium/discovery.py
@@ -8,14 +8,17 @@ import sqlparse
 from sqlparse.sql import Identifier, IdentifierList
 
 from nerium.query import parse_query_file
+from raw import db
 
 
 def list_reports():
     """Return list of available report names from query dir"""
-    flat_queries = list(Path(os.getenv("QUERY_PATH", "query_files")).glob("**/*"))
+    flat_queries = db.list_queries()
     # Filter out docs and metadata
-    query_paths = list(filter(lambda i: i.suffix not in [".md", ".yaml"], flat_queries))
-    query_names = [i.stem for i in query_paths]
+    # query_paths = list(filter(lambda i: i.suffix not in [".md", ".yaml"], flat_queries))
+    # rg = re.compile("[ \\w-]+?(?=\\.)")
+    query_names = [Path(i).stem for i in flat_queries]
+
     query_names.sort()
     reports = dict(reports=query_names)
     return reports

--- a/nerium/discovery.py
+++ b/nerium/discovery.py
@@ -14,9 +14,6 @@ from raw import db
 def list_reports():
     """Return list of available report names from query dir"""
     flat_queries = db.list_queries()
-    # Filter out docs and metadata
-    # query_paths = list(filter(lambda i: i.suffix not in [".md", ".yaml"], flat_queries))
-    # rg = re.compile("[ \\w-]+?(?=\\.)")
     query_names = [Path(i).stem for i in flat_queries]
 
     query_names.sort()

--- a/nerium/query.py
+++ b/nerium/query.py
@@ -1,4 +1,3 @@
-# import os
 import re
 from collections import namedtuple
 from datetime import datetime
@@ -47,10 +46,12 @@ def extract_metadata(query_string):
 
 def read_query_file(path):
     if path.startswith("s3://"):
+        # Read file from S3 and convert to string with decode()
         fs = s3fs.S3FileSystem(anon=False)
-        with fs.open(path, "rt") as f:
-            statement = f.read()
+        with fs.open(path, "rb") as f:
+            statement = f.read().decode()
     else:
+        # Read file as text from local filesystem
         with open(path, "rt") as f:
             statement = f.read()
     return statement

--- a/nerium/query.py
+++ b/nerium/query.py
@@ -3,12 +3,8 @@ import re
 from collections import namedtuple
 from datetime import datetime
 
-# from pathlib import Path
-
+import s3fs
 import yaml
-
-# from jinja2.sandbox import SandboxedEnvironment
-
 from raw import db
 
 
@@ -49,23 +45,30 @@ def extract_metadata(query_string):
     return metadata
 
 
+def read_query_file(path):
+    if path.startswith("s3://"):
+        fs = s3fs.S3FileSystem(anon=False)
+        with fs.open(path, "rt") as f:
+            statement = f.read()
+    else:
+        with open(path, "rt") as f:
+            statement = f.read()
+    return statement
+
+
 def parse_query_file(query_name):
     """Parse query file and add query statement and metadata."""
     query_obj = init_query(query_name)
-    try:
-        with open(query_obj.path) as f:
-            statement = f.read()
 
-        metadata = extract_metadata(statement)
-
-        query_obj = query_obj._replace(metadata=metadata, statement=statement)
-
-    # Set 404 if no file matches query_name
-    except (FileNotFoundError, TypeError):
+    if not query_obj.path:
         query_obj = query_obj._replace(
             error=f"No query found matching '{query_name}'", status_code=404
         )
+        return query_obj
 
+    statement = read_query_file(query_obj.path)
+    metadata = extract_metadata(statement)
+    query_obj = query_obj._replace(metadata=metadata, statement=statement)
     return query_obj
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ smmap==5.0.0
     # via gitdb
 sqla-raw==1.4.0
     # via Nerium (setup.py)
-sqlalchemy==1.4.41
+sqlalchemy==1.4.42
     # via sqla-raw
 sqlparse==0.4.3
     # via Nerium (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,28 @@
 #
 #    pip-compile
 #
-certifi==2022.9.14
+aiobotocore==2.4.0
+    # via s3fs
+aiohttp==3.8.3
+    # via
+    #   aiobotocore
+    #   s3fs
+aioitertools==0.11.0
+    # via aiobotocore
+aiosignal==1.2.0
+    # via aiohttp
+async-timeout==4.0.2
+    # via aiohttp
+attrs==22.1.0
+    # via aiohttp
+botocore==1.27.59
+    # via aiobotocore
+certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1
-    # via requests
+    # via
+    #   aiohttp
+    #   requests
 click==8.1.3
     # via flask
 flask==2.0.2
@@ -16,45 +34,73 @@ flask==2.0.2
     #   flask-cors
 flask-cors==3.0.10
     # via Nerium (setup.py)
+frozenlist==1.3.1
+    # via
+    #   aiohttp
+    #   aiosignal
+fsspec==2022.8.2
+    # via s3fs
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.27
+gitpython==3.1.29
     # via Nerium (setup.py)
-greenlet==1.1.3
+greenlet==1.1.3.post0
     # via sqlalchemy
 idna==3.4
-    # via requests
+    # via
+    #   requests
+    #   yarl
 itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
     # via
     #   flask
     #   sqla-raw
+jmespath==1.0.1
+    # via botocore
 markupsafe==2.1.1
     # via jinja2
 marshmallow==3.18.0
     # via Nerium (setup.py)
+multidict==6.0.2
+    # via
+    #   aiohttp
+    #   yarl
 packaging==21.3
     # via marshmallow
 pyparsing==3.0.9
     # via packaging
+python-dateutil==2.8.2
+    # via botocore
 pyyaml==6.0
     # via Nerium (setup.py)
 requests==2.28.1
     # via Nerium (setup.py)
+s3fs==2022.8.2
+    # via sqla-raw
 six==1.16.0
-    # via flask-cors
+    # via
+    #   flask-cors
+    #   python-dateutil
 smmap==5.0.0
     # via gitdb
-sqla-raw==1.3.0
+sqla-raw==1.4.0
     # via Nerium (setup.py)
 sqlalchemy==1.4.41
     # via sqla-raw
-sqlparse==0.4.2
+sqlparse==0.4.3
     # via Nerium (setup.py)
+typing-extensions==4.4.0
+    # via aioitertools
 urllib3==1.26.12
-    # via requests
+    # via
+    #   botocore
+    #   requests
 werkzeug==2.0.3
     # via
     #   Nerium (setup.py)
     #   flask
+wrapt==1.14.1
+    # via aiobotocore
+yarl==1.8.1
+    # via aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ six==1.16.0
     #   python-dateutil
 smmap==5.0.0
     # via gitdb
-sqla-raw==1.4.0
+sqla-raw==1.4.1
     # via Nerium (setup.py)
 sqlalchemy==1.4.42
     # via sqla-raw

--- a/tests/nerium_test.py
+++ b/tests/nerium_test.py
@@ -75,21 +75,21 @@ def test_health_check(client):
 
 
 def test_sql_error(client):
-    url = "/v2/results/error_test"
+    url = "/v1/error_test"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 400
     assert "error" in resp.get_json().keys()
 
 
 def test_missing_query_error(client):
-    url = "/v2/results/not_a_query"
+    url = "/v1/not_a_query"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 404
     assert "error" in resp.get_json().keys()
 
 
 def test_missing_report_error(client):
-    url = "/v2/reports/not_a_query"
+    url = "/v1/not_a_query/docs"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 404
     assert "error" in resp.get_json().keys()
@@ -120,28 +120,28 @@ def test_auth_header_not_required(client):
 
 
 def test_get_query(client):
-    url = f"/v2/results/{query_name}"
+    url = f"/v1/{query_name}"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 200
     assert EXPECTED == resp.get_json()["data"]
 
 
 def test_results_csv(client):
-    url = f"/v2/results/{query_name}/csv"
+    url = f"/v1/{query_name}/csv"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.headers["content_type"] == "text/csv"
     assert str(resp.data, "utf-8") == CSV_EXPECTED
 
 
 def test_results_compact(client):
-    url = f"/v2/results/{query_name}/compact"
+    url = f"/v1/{query_name}/compact"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 200
     assert COMPACT_EXPECTED == resp.get_json()
 
 
 def test_result_json(client):
-    url = "/v2/results"
+    url = "/v1/test"
     data = dict(query_name="test", format="compact")
     resp = client.get(url, json=data, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 200
@@ -149,28 +149,28 @@ def test_result_json(client):
 
 
 def test_reports_list(client):
-    url = "/v2/reports/"
+    url = "/v1/docs/"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 200
     assert resp.get_json() == {"reports": ["error_test", "test", "test_body"]}
 
 
 def test_report_descr(client):
-    url = f"/v2/reports/{query_name}"
+    url = f"/v1/{query_name}/docs"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 200
     assert resp.get_json() == DESCR_EXPECTED
 
 
 def test_report_descr_body(client):
-    url = "/v2/reports/test_body"
+    url = "/v1/test_body/docs"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 200
     assert "columns" in resp.get_json().keys()
 
 
 def test_report_descr_error(client):
-    url = "/v2/reports/goo"
+    url = "/v1/goo/docs"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 404
     assert ("error", "No query found matching 'goo'") in resp.get_json().items()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,7 +6,7 @@
 #
 attrs==22.1.0
     # via pytest
-coverage[toml]==6.4.4
+coverage[toml]==6.5.0
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -24,7 +24,7 @@ pytest==7.1.3
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r requirements.in
 tomli==2.0.1
     # via


### PR DESCRIPTION
- move `v2/reports/<query_name>` endpoints to `<query_name>/docs`
- /docs endpoints are backwards-compatible w/ `v1` API routes, so this removes `v2` and all `v2/results/<query_name>` endpoints
- Upgrade `sqla-raw` to 1.4.0 for `s3fs` support
- Add `s3fs` support to query parsing and discovery/documentation methods