### PR TITLE
adds streaming support

### DIFF
--- a/nerium/__version__.py
+++ b/nerium/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 12, 1)
+VERSION = (0, 13, 0)
 
 __version__ = ".".join(map(str, VERSION))

--- a/nerium/query.py
+++ b/nerium/query.py
@@ -110,7 +110,7 @@ def serialize_stream(query_name, writer_constructor, **kwargs):
 
     result = db.stream_result_by_name(query_name, **kwargs)
     # Initialization here (outside of a generator) allows for
-    # exception handling in `wrap_results_in_query` and an HTTP error
+    # exception handling in `query_decorator` and an HTTP error
     # return prior to starting a 200 streaming HTTP
     # response. Otherwise, an exception raised from within the
     # generator iteration would occur after the stream response is returned

--- a/nerium/streaming.py
+++ b/nerium/streaming.py
@@ -1,0 +1,87 @@
+import abc
+
+from io import StringIO
+from raw import db
+
+BUFFER_SIZE = 16384
+
+
+def initialize_stream(iterable, writer_constructor):
+    """Initialize a stream and writer. Popping the first record from
+    the iterable allows both for error handling prior to entering a
+    stream generator as well as header formatting. The first record will
+    be written to the `stream` buffer here.
+
+    Args:
+        `iterable`: an iterable of results, e.g. a generator streaming
+            a sqlalchemy cursor
+        `writer_constructor`: a class or callable whose return
+            implements the BufferWriter interface
+
+    Returns:
+        A tuple containing, respectively, a stream (StringIO stream
+        buffer) and a writer (implementing BufferWriter). These can be
+        passed to yield_stream along with the original `iterable` to
+        yield the stream until completion
+
+    """
+
+    stream = StringIO()
+
+    try:
+        first = next(iterable)
+    except StopIteration:
+        return stream, None
+
+    writer = writer_constructor(stream, first)
+    writer.write(first)
+
+    return stream, writer
+
+
+def yield_stream(iterable, stream, writer):
+    """Buffers contents of iterable to stream and yields blocks of
+    BUFFER_SIZE until completion. Arguments `stream` and `writer` are
+    expected to be the return values of `initialize_stream`.
+
+    Args:
+        `iterable`: an iterable of results, e.g. a generator streaming
+            a sqlalchemy cursor
+        `stream`: an iterable of results, e.g. a generator streaming
+            a sqlalchemy cursor
+        `writer`: serializes each record in the iterable to the
+            StringIO buffer. Implements the BufferWriter interface.
+
+    Yields:
+        bytes: serialized records form iterable
+
+    """
+
+    for row in iterable:
+        writer.write(row)
+        if stream.tell() > BUFFER_SIZE:
+            yield _flush(stream)
+    yield _flush(stream)
+
+
+def _flush(stream):
+    """Consume the current StringIO buffer and return the contents"""
+
+    stream.seek(0)
+    data = stream.read()
+    stream.truncate(0)
+    stream.seek(0)
+
+    return data
+
+
+class BufferWriter(metaclass=abc.ABCMeta):
+    """Interface specifying serialization to a StringIO buffer"""
+
+    @abc.abstractmethod
+    def __init__(self, stream, first_record):
+        pass
+
+    @abc.abstractmethod
+    def write(self, record):
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ six==1.16.0
     #   python-dateutil
 smmap==5.0.0
     # via gitdb
-sqla-raw==1.4.1
+sqla-raw==1.5.0
     # via Nerium (setup.py)
 sqlalchemy==1.4.42
     # via sqla-raw

--- a/tests/nerium_test.py
+++ b/tests/nerium_test.py
@@ -129,8 +129,15 @@ def test_get_query(client):
 def test_results_csv(client):
     url = f"/v1/{query_name}/csv"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
-    assert resp.headers["content_type"] == "text/csv"
+    assert "text/csv" in resp.headers["content-type"]
     assert str(resp.data, "utf-8") == CSV_EXPECTED
+
+
+def test_results_csv_error(client):
+    url = "/v1/error_test/csv"
+    resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
+    assert resp.status_code == 400
+    assert "no such table: not_a_table" in str(resp.data, "utf-8")
 
 
 def test_results_compact(client):

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -1,0 +1,36 @@
+import pytest
+
+from nerium import streaming
+
+class Writer(streaming.BufferWriter):
+    def __init__(self, stream, _first):
+        self.stream = stream
+
+    def write(self, record):
+        self.stream.write(f"<{record}>")
+
+
+@pytest.fixture
+def results():
+    max_record = 2918  # chosen from BUFFER_SIZE + serialization length
+    return (i for i in range(max_record))
+
+
+def test_initialize_stream(results):
+    stream, writer = streaming.initialize_stream(results, Writer)
+    assert stream.getvalue() == '<0>'
+    assert next(results) == 1
+
+
+def test_initialize_stream_empty_iterator():
+    stream, writer = streaming.initialize_stream(iter(()), None)
+    assert stream.getvalue() == ''
+
+
+def test_yield_stream(results):
+    stream, writer = streaming.initialize_stream(results, Writer)
+    blocks = list(streaming.yield_stream(results, stream, writer))
+    assert '<0><1><2><3>' in blocks[0]
+    assert '<2914><2915>' in blocks[0]
+    assert '<2916><2917>' in blocks[1]
+    assert stream.getvalue() == ''

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -12,7 +12,7 @@ class Writer(streaming.BufferWriter):
 
 @pytest.fixture
 def results():
-    max_record = 2918  # chosen from BUFFER_SIZE + serialization length
+    max_record = 2918  # chosen from BUFFER_SIZE and serialization length
     return (i for i in range(max_record))
 
 


### PR DESCRIPTION
Does
- adds generalized streaming support
- implements csv streaming
- error handling prior to stream initialization

Doesn't 
- add streaming JSON support yet, but should be a small step from here

Draft: Requires https://github.com/nerium-data/sqla-raw/pull/20 

### testing notes

developed against editable egg linked for `sqla-raw`

```bash
pip uninstall sqla-raw
pip install -e <path-to-sqla-raw>
```

```bash
DATABASE_URL=X QUERY_PATH=Y FLASK_APP=nerium/app.py /usr/bin/time -lph flask run
```

```bash
time curl http://127.0.0.1:5000/v1/query1/csv | wc -l
```

```sql
-- select * from rel1 limit 0;
-- select * from rel1 limit 10000;
select * from rel1 limit 100000;
-- select * from rel1 limit 1000000;
-- select * from rel1 limit 10000000;
```

### memory profiling

Current memory high watermark caps out around 80MB, where the current main is linear in the result set.

<p align="center"><img width="473" alt="image" src="https://user-images.githubusercontent.com/4062890/204605584-da9150ac-21e4-448b-8d72-bbc04c25200c.png"></p>

### performance

there is a bit of a performance hit. potentially due to additional generator frames, potentially due to sqla conn buffer round trips, probably further tunable

<p align="center"><img width="468" alt="image" src="https://user-images.githubusercontent.com/4062890/204605812-3bfd5914-a61f-48b8-a07f-875ed7afa46f.png"></p>
