### PR TITLE
Add kwargs to yield_stream parameters

### DIFF
--- a/nerium/streaming.py
+++ b/nerium/streaming.py
@@ -38,7 +38,7 @@ def initialize_stream(iterable, writer_constructor):
     return stream, writer
 
 
-def yield_stream(iterable, stream, writer):
+def yield_stream(iterable, stream, writer, **kwargs):
     """Buffers contents of iterable to stream and yields blocks of
     BUFFER_SIZE until completion. Arguments `stream` and `writer` are
     expected to be the return values of `initialize_stream`.

--- a/tests/nerium_test.py
+++ b/tests/nerium_test.py
@@ -62,7 +62,7 @@ def test_dir(monkeypatch):
 
 
 def test_results_expected():
-    result = query.get_result_set(query_name)
+    result = query.get_result_set(query_name, greeting="yo")
     assert result.result == EXPECTED
 
 
@@ -120,14 +120,14 @@ def test_auth_header_not_required(client):
 
 
 def test_get_query(client):
-    url = f"/v1/{query_name}"
+    url = f"/v1/{query_name}?greeting=yo"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 200
     assert EXPECTED == resp.get_json()["data"]
 
 
 def test_results_csv(client):
-    url = f"/v1/{query_name}/csv"
+    url = f"/v1/{query_name}/csv?greeting=yo"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert "text/csv" in resp.headers["content-type"]
     assert str(resp.data, "utf-8") == CSV_EXPECTED
@@ -141,7 +141,7 @@ def test_results_csv_error(client):
 
 
 def test_results_compact(client):
-    url = f"/v1/{query_name}/compact"
+    url = f"/v1/{query_name}/compact?greeting=yo"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 200
     assert COMPACT_EXPECTED == resp.get_json()
@@ -149,7 +149,7 @@ def test_results_compact(client):
 
 def test_result_json(client):
     url = "/v1/test"
-    data = dict(query_name="test", format="compact")
+    data = dict(query_name="test", format="compact", greeting="yo")
     resp = client.get(url, json=data, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 200
     assert COMPACT_EXPECTED == resp.get_json()

--- a/tests/query/test.sql
+++ b/tests/query/test.sql
@@ -20,5 +20,5 @@ select cast(1.25 as float) as foo  -- float check
     union
     select 42
         , strftime('%Y-%m-%d','2031-05-25')
-        , 'yo'
+        , :greeting 
         , 'ƺƺƺƺ';

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from nerium import streaming
 
+
 class Writer(streaming.BufferWriter):
     def __init__(self, stream, _first):
         self.stream = stream
@@ -18,19 +19,19 @@ def results():
 
 def test_initialize_stream(results):
     stream, writer = streaming.initialize_stream(results, Writer)
-    assert stream.getvalue() == '<0>'
+    assert stream.getvalue() == "<0>"
     assert next(results) == 1
 
 
 def test_initialize_stream_empty_iterator():
     stream, writer = streaming.initialize_stream(iter(()), None)
-    assert stream.getvalue() == ''
+    assert stream.getvalue() == ""
 
 
 def test_yield_stream(results):
     stream, writer = streaming.initialize_stream(results, Writer)
     blocks = list(streaming.yield_stream(results, stream, writer))
-    assert '<0><1><2><3>' in blocks[0]
-    assert '<2914><2915>' in blocks[0]
-    assert '<2916><2917>' in blocks[1]
-    assert stream.getvalue() == ''
+    assert "<0><1><2><3>" in blocks[0]
+    assert "<2914><2915>" in blocks[0]
+    assert "<2916><2917>" in blocks[1]
+    assert stream.getvalue() == ""


### PR DESCRIPTION
0.13.0 release with streaming for CSVs had a small bug: `yield_stream()` was not expecting `**kwargs` such as used for SQL query bind variable parameters from the request. CSV report unit test was passing, because the fixture test query didn't require any parameters. Fix was simply adding `**kwargs` to the `yield_stream` method signature. Updated test query cases to require passing a bind variable to the test query and verified that the fix gets them to pass again