### PR TITLE
Add csv.gz format

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Unknown values of `format` will silently fall back to default.
 'default': `{"name": "<query_name>", "data": [{<column_name>:<row_value>, etc..., }, {etc...}, ], "metadata": {<key>: <value>, etc..., }, "params": {<array of name-value pairs submitted to query with request>}}`  
 'compact': `{"columns": [<list of column names>], "data": [<array of row value arrays>]}`
 'csv': `<csv formatted string (with \r\n newline)>`
+'csv.gz': `<gzip compressed csv stream>`
   
 Of course, it is possible that a database query might return no results. In this case, Nerium will respond with an empty JSON array `[]` for the `data` attribute, regardless of specified format. This is not considered an error, and clients should be prepared to handle it appropriately.
 

--- a/nerium/app.py
+++ b/nerium/app.py
@@ -106,6 +106,27 @@ def serve_csv_result(query_name):
     return response
 
 
+@app.route("/v1/<query_name>/csv.gz")
+@app.route("/v2/results/<query_name>/csv.gz")
+@require_api_key
+def serve_csvgz_result(query_name):
+    """Parse request and stream gzipped CSV back"""
+
+    params = parse_query_params()
+    if 'format_' not in params:
+        params['format_'] = 'csv.gz'
+
+    query = csv_result.results_to_csv(query_name, **params)
+
+    if query.error:
+        return (query.error, 400)
+
+    response = Response(query.result, mimetype='application/gzip')
+    response.headers['Content-Disposition'] = f"attachment; filename={query_name}.csv.gz"
+
+    return response
+
+
 @app.route("/v1/docs/")
 @require_api_key
 def serve_report_list():

--- a/nerium/csv_result.py
+++ b/nerium/csv_result.py
@@ -1,6 +1,7 @@
 from csv import DictWriter
 from gzip import GzipFile
 from io import TextIOWrapper
+from io import StringIO, BytesIO
 
 from nerium.query import serialize_stream
 from nerium.streaming import BufferWriterBase
@@ -33,9 +34,9 @@ class GzipCompressWriteStream(BufferWriterBase):
 class CsvStreamWriter(BufferWriterBase):
     """Serializes dicts to a StringIO buffer"""
 
-    def __init__(self, stream, first_record):
-        super().__init__(stream)
-        self.writer = DictWriter(stream, fieldnames=first_record.keys())
+    def __init__(self, first_record):
+        super().__init__(StringIO())
+        self.writer = DictWriter(self._target_stream, fieldnames=first_record.keys())
         self.writer.writeheader()
 
     def write(self, record):
@@ -51,11 +52,11 @@ class CsvStreamWriter(BufferWriterBase):
 
 
 class CsvGzipStreamWriter(BufferWriterBase):
-    """Serializes dicts to a compressed StringIO buffer"""
+    """Serializes dicts to a compressed BytesIO buffer"""
 
-    def __init__(self, stream, first_record):
-        super().__init__(stream)
-        self.gzip_stream = GzipCompressWriteStream(stream)
+    def __init__(self, first_record):
+        super().__init__(BytesIO())
+        self.gzip_stream = GzipCompressWriteStream(self._target_stream)
 
         self.writer = DictWriter(self.gzip_stream, fieldnames=first_record.keys())
         self.writer.writeheader()

--- a/nerium/csv_result.py
+++ b/nerium/csv_result.py
@@ -1,14 +1,40 @@
 from csv import DictWriter
+from gzip import GzipFile
+from io import TextIOWrapper
 
 from nerium.query import serialize_stream
 from nerium.streaming import BufferWriter
+
+
+class GzipCompressWriteStream(BufferWriter):
+    def __init__(self, stream):
+        self.write_stream = stream
+        self.binary_file = GzipFile(fileobj=stream, mode='wb')
+        encoding = 'utf-8'
+
+        self.text_io = TextIOWrapper(
+                self.binary_file,
+                encoding,
+                write_through=True,
+                line_buffering=False,
+                errors='strict')
+
+    def write(self, data):
+        self.text_io.write(data)
+
+    def close(self):
+        self.binary_file.close()
+
+    def flush(self):
+        self.text_io.flush()
+        self.binary_file.flush()
 
 
 class CsvStreamWriter(BufferWriter):
     """Serializes dicts to a StringIO buffer"""
 
     def __init__(self, stream, first_record):
-        self.stream = stream
+        self.write_stream = stream
         self.writer = DictWriter(stream, fieldnames=first_record.keys())
         self.writer.writeheader()
 
@@ -17,8 +43,38 @@ class CsvStreamWriter(BufferWriter):
 
         self.writer.writerow(record)
 
+    def close(self):
+        pass
+
+    def flush(self):
+        pass
+
+
+class CsvGzipStreamWriter(BufferWriter):
+    """Serializes dicts to a compressed StringIO buffer"""
+
+    def __init__(self, stream, first_record):
+        self.write_stream = stream
+        self.gzip_stream = GzipCompressWriteStream(stream)
+
+        self.writer = DictWriter(self.gzip_stream, fieldnames=first_record.keys())
+        self.writer.writeheader()
+
+    def write(self, record):
+        """Absraction to support writers with methods other than writerow"""
+
+        self.writer.writerow(record)
+
+    def close(self):
+        self.gzip_stream.close()
+
+    def flush(self):
+        self.gzip_stream.flush()
+
 
 def results_to_csv(query_name, **kwargs):
     """Generate CSV from result data"""
 
-    return serialize_stream(query_name, CsvStreamWriter, **kwargs)
+    writer = CsvGzipStreamWriter if kwargs.get("format_") == "csv.gz" else CsvStreamWriter
+
+    return serialize_stream(query_name, writer, **kwargs)

--- a/nerium/csv_result.py
+++ b/nerium/csv_result.py
@@ -3,12 +3,12 @@ from gzip import GzipFile
 from io import TextIOWrapper
 
 from nerium.query import serialize_stream
-from nerium.streaming import BufferWriter
+from nerium.streaming import BufferWriterBase
 
 
-class GzipCompressWriteStream(BufferWriter):
+class GzipCompressWriteStream(BufferWriterBase):
     def __init__(self, stream):
-        self.write_stream = stream
+        super().__init__(stream)
         self.binary_file = GzipFile(fileobj=stream, mode='wb')
         encoding = 'utf-8'
 
@@ -30,11 +30,11 @@ class GzipCompressWriteStream(BufferWriter):
         self.binary_file.flush()
 
 
-class CsvStreamWriter(BufferWriter):
+class CsvStreamWriter(BufferWriterBase):
     """Serializes dicts to a StringIO buffer"""
 
     def __init__(self, stream, first_record):
-        self.write_stream = stream
+        super().__init__(stream)
         self.writer = DictWriter(stream, fieldnames=first_record.keys())
         self.writer.writeheader()
 
@@ -50,11 +50,11 @@ class CsvStreamWriter(BufferWriter):
         pass
 
 
-class CsvGzipStreamWriter(BufferWriter):
+class CsvGzipStreamWriter(BufferWriterBase):
     """Serializes dicts to a compressed StringIO buffer"""
 
     def __init__(self, stream, first_record):
-        self.write_stream = stream
+        super().__init__(stream)
         self.gzip_stream = GzipCompressWriteStream(stream)
 
         self.writer = DictWriter(self.gzip_stream, fieldnames=first_record.keys())

--- a/nerium/debug.py
+++ b/nerium/debug.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+
+class DebugModeChecker:
+
+    @staticmethod
+    def is_debug_mode():
+        return app.debug

--- a/nerium/query.py
+++ b/nerium/query.py
@@ -1,4 +1,5 @@
 import re
+import traceback
 from collections import namedtuple
 from datetime import datetime
 
@@ -6,6 +7,7 @@ import s3fs
 import yaml
 from raw import db
 from nerium import streaming
+from nerium.debug import DebugModeChecker
 
 
 def init_query(query_name):
@@ -91,7 +93,9 @@ def query_decorator(func):
             result = func(query_name, *args, **kwargs)
             query = query._replace(result=result)
         except Exception as e:
-            query = query._replace(error=repr(e), status_code=400)
+            error = traceback.format_exc() if DebugModeChecker.is_debug_mode() else repr(e)
+
+            query = query._replace(error=error, status_code=400)
 
         return query
     return inner
@@ -114,6 +118,6 @@ def serialize_stream(query_name, writer_constructor, **kwargs):
     # return prior to starting a 200 streaming HTTP
     # response. Otherwise, an exception raised from within the
     # generator iteration would occur after the stream response is returned
-    stream, writer = streaming.initialize_stream(result, writer_constructor)
+    stream, writer = streaming.initialize_stream(result, writer_constructor, **kwargs)
 
     return streaming.yield_stream(result, stream, writer, **kwargs)

--- a/nerium/query.py
+++ b/nerium/query.py
@@ -118,6 +118,6 @@ def serialize_stream(query_name, writer_constructor, **kwargs):
     # return prior to starting a 200 streaming HTTP
     # response. Otherwise, an exception raised from within the
     # generator iteration would occur after the stream response is returned
-    stream, writer = streaming.initialize_stream(result, writer_constructor, **kwargs)
+    writer = streaming.initialize_stream(result, writer_constructor, **kwargs)
 
-    return streaming.yield_stream(result, stream, writer, **kwargs)
+    return streaming.yield_stream(result, writer, **kwargs)

--- a/nerium/streaming.py
+++ b/nerium/streaming.py
@@ -6,10 +6,10 @@ BUFFER_SIZE = 16384
 
 
 def initialize_stream(iterable, writer_constructor, **kwargs):
-    """Initialize a stream and writer. Popping the first record from
+    """Initialize a BufferWriter. Popping the first record from
     the iterable allows both for error handling prior to entering a
     stream generator as well as header formatting. The first record will
-    be written to the `stream` buffer here.
+    be written with the `writer` here.
 
     Args:
         `iterable`: an iterable of results, e.g. a generator streaming
@@ -18,10 +18,9 @@ def initialize_stream(iterable, writer_constructor, **kwargs):
             implements the BufferWriter interface
 
     Returns:
-        A tuple containing, respectively, a stream (StringIO stream
-        buffer) and a writer (implementing BufferWriter). These can be
-        passed to yield_stream along with the original `iterable` to
-        yield the stream until completion
+        A writer (implementing BufferWriter). This can be passed to
+        `yield_stream` along with the original `iterable` to yield the stream
+        until completion.
 
     """
 
@@ -39,14 +38,12 @@ def initialize_stream(iterable, writer_constructor, **kwargs):
 
 
 def yield_stream(iterable, writer, **kwargs):
-    """Buffers contents of iterable to stream and yields blocks of
-    BUFFER_SIZE until completion. Arguments `stream` and `writer` are
-    expected to be the return values of `initialize_stream`.
+    """Buffers contents of iterable to writer/stream and yields blocks of
+    BUFFER_SIZE until completion. Argument `writer` is expected to be the
+    return values of `initialize_stream`.
 
     Args:
         `iterable`: an iterable of results, e.g. a generator streaming
-            a sqlalchemy cursor
-        `stream`: an iterable of results, e.g. a generator streaming
             a sqlalchemy cursor
         `writer`: serializes each record in the iterable to the
             StringIO buffer. Implements the BufferWriter interface.

--- a/nerium/streaming.py
+++ b/nerium/streaming.py
@@ -30,7 +30,7 @@ def initialize_stream(iterable, writer_constructor, **kwargs):
     try:
         first = next(iterable)
     except StopIteration:
-        return None
+        return NullBufferWriter(stream)
 
     writer = writer_constructor(stream, first)
     writer.write(first)
@@ -140,3 +140,20 @@ class BufferWriterBase(BufferWriter):
 
     def flush(self):
         raise NotImplementedError
+
+
+class NullBufferWriter(BufferWriterBase):
+    def __init__(self, stream):
+        super().__init__(stream)
+
+    def write(self, data):
+        pass
+
+    def consume_target_stream(self):
+        return ""
+
+    def close(self):
+        pass
+
+    def flush(self):
+        pass

--- a/tests/nerium_test.py
+++ b/tests/nerium_test.py
@@ -133,6 +133,13 @@ def test_results_csv(client):
     assert str(resp.data, "utf-8") == CSV_EXPECTED
 
 
+def test_results_csvgz(client):
+    url = f"/v1/{query_name}/csv.gz?greeting=yo"
+    resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
+    assert "application/gzip" in resp.headers["content-type"]
+    assert len(resp.data) > 0
+
+
 def test_results_csv_error(client):
     url = "/v1/error_test/csv"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})

--- a/tests/nerium_test.py
+++ b/tests/nerium_test.py
@@ -133,6 +133,13 @@ def test_results_csv(client):
     assert str(resp.data, "utf-8") == CSV_EXPECTED
 
 
+def test_results_csv_error(client):
+    url = "/v1/error_test/csv"
+    resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
+    assert resp.status_code == 400
+    assert "no such table: not_a_table" in str(resp.data, "utf-8")
+
+
 def test_results_csvgz(client):
     url = f"/v1/{query_name}/csv.gz?greeting=yo"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
@@ -140,11 +147,15 @@ def test_results_csvgz(client):
     assert len(resp.data) > 0
 
 
-def test_results_csv_error(client):
-    url = "/v1/error_test/csv"
+def test_results_csvgz_error(client):
+    url = "/v1/error_test/csv.gz"
     resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
     assert resp.status_code == 400
     assert "no such table: not_a_table" in str(resp.data, "utf-8")
+    url = f"/v1/{query_name}/csv.gz?greeting=yo"
+    resp = client.get(url, headers={"X-API-Key": TEST_API_KEY})
+    assert "application/gzip" in resp.headers["content-type"]
+    assert len(resp.data) > 0
 
 
 def test_results_compact(client):

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -62,13 +62,13 @@ def byte_results():
 
 def test_initialize_stream(results):
     writer = streaming.initialize_stream(results, Writer, format_="csv")
-    assert writer.target_stream.getvalue() == "<0>"
+    assert writer.consume_target_stream() == "<0>"
     assert next(results) == 1
 
 
 def test_initialize_stream_compressed(byte_results):
     writer = streaming.initialize_stream(byte_results, BytesWriter, format_="csv.gz")
-    assert writer.target_stream.getvalue() == b'\x00\x00'
+    assert writer.consume_target_stream() == b'\x00\x00'
     assert next(byte_results) == b'\x00\x01'
 
 
@@ -83,4 +83,4 @@ def test_yield_stream(results):
     assert "<0><1><2><3>" in blocks[0]
     assert "<2914><2915>" in blocks[0]
     assert "<2916><2917>" in blocks[1]
-    assert writer.target_stream.getvalue() == ""
+    assert writer.consume_target_stream() == ""

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -74,7 +74,6 @@ def test_initialize_stream_compressed(byte_results):
 
 def test_initialize_stream_empty_iterator():
     writer = streaming.initialize_stream(iter(()), None)
-    #   assert writer.target_stream.getvalue() == ""
     assert writer == None
 
 

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -79,7 +79,7 @@ def test_yield_stream_bytes(byte_results):
     writer = streaming.initialize_stream(byte_results, BytesWriter)
     blocks = list(streaming.yield_stream(byte_results, writer))
     assert b'\x00\x01\x00\x02' in blocks[0] # beginning of block
-    assert b'\x0b\x64\x0b\x65' in blocks[0] # end of block
+    assert b'\x1f\xff\x20\x00' in blocks[0] # end of block
     assert b'\x20\x01\x20\x02' in blocks[1] # beginning of block
     assert b'\x23\x26\x23\x27' in blocks[1] # end of block
     assert writer.consume_target_stream() == b''

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -10,6 +10,27 @@ class Writer(streaming.BufferWriter):
     def write(self, record):
         self.stream.write(f"<{record}>")
 
+    def close(self):
+        pass
+
+    def flush(self):
+        pass
+
+
+class BytesWriter(streaming.BufferWriter):
+
+    def __init__(self, stream, _first):
+        self.stream = stream
+
+    def write(self, record):
+        self.stream.write(record)
+
+    def close(self):
+        pass
+
+    def flush(self):
+        pass
+
 
 @pytest.fixture
 def results():
@@ -17,10 +38,22 @@ def results():
     return (i for i in range(max_record))
 
 
+@pytest.fixture
+def byte_results():
+    max_record = 2918  # chosen from BUFFER_SIZE and serialization length
+    return (i.to_bytes(2, 'big') for i in range(max_record))
+
+
 def test_initialize_stream(results):
-    stream, writer = streaming.initialize_stream(results, Writer)
+    stream, writer = streaming.initialize_stream(results, Writer, format_="csv")
     assert stream.getvalue() == "<0>"
     assert next(results) == 1
+
+
+def test_initialize_stream_compressed(byte_results):
+    stream, writer = streaming.initialize_stream(byte_results, BytesWriter, format_="csv.gz")
+    assert stream.getvalue() == b'\x00\x00'
+    assert next(byte_results) == b'\x00\x01'
 
 
 def test_initialize_stream_empty_iterator():

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -74,7 +74,7 @@ def test_initialize_stream_compressed(byte_results):
 
 def test_initialize_stream_empty_iterator():
     writer = streaming.initialize_stream(iter(()), None)
-    assert writer == None
+    assert writer.consume_target_stream() == ""
 
 
 def test_yield_stream(results):

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -1,19 +1,13 @@
 import pytest
 
 from nerium import streaming
+from io import StringIO, BytesIO
 
 
 class Writer(streaming.BufferWriterBase):
-    def __init__(self, stream, _first):
-        self._target_stream = stream
 
-    @property
-    def target_stream(self):
-        return self._target_stream
-
-    @target_stream.setter
-    def target_stream(self, stream):
-        self._target_stream = stream
+    def __init__(self, _first):
+        super().__init__(StringIO())
 
     def write(self, record):
         self._target_stream.write(f"<{record}>")
@@ -27,16 +21,8 @@ class Writer(streaming.BufferWriterBase):
 
 class BytesWriter(streaming.BufferWriterBase):
 
-    def __init__(self, stream, _first):
-        self._target_stream = stream
-
-    @property
-    def target_stream(self):
-        return self._target_stream
-
-    @target_stream.setter
-    def target_stream(self, stream):
-        self._target_stream = stream
+    def __init__(self, _first):
+        super().__init__(BytesIO())
 
     def write(self, record):
         self._target_stream.write(record)
@@ -56,24 +42,27 @@ def results():
 
 @pytest.fixture
 def byte_results():
-    max_record = 2918  # chosen from BUFFER_SIZE and serialization length
+    max_record = 9000  # chosen > BUFFER_SIZE
     return (i.to_bytes(2, 'big') for i in range(max_record))
 
 
 def test_initialize_stream(results):
     writer = streaming.initialize_stream(results, Writer, format_="csv")
+    assert writer.target_stream_size() == 3
     assert writer.consume_target_stream() == "<0>"
     assert next(results) == 1
 
 
 def test_initialize_stream_compressed(byte_results):
     writer = streaming.initialize_stream(byte_results, BytesWriter, format_="csv.gz")
+    assert writer.target_stream_size() == 2
     assert writer.consume_target_stream() == b'\x00\x00'
     assert next(byte_results) == b'\x00\x01'
 
 
 def test_initialize_stream_empty_iterator():
     writer = streaming.initialize_stream(iter(()), None)
+    assert writer.target_stream_size() == 0
     assert writer.consume_target_stream() == ""
 
 
@@ -84,3 +73,13 @@ def test_yield_stream(results):
     assert "<2914><2915>" in blocks[0]
     assert "<2916><2917>" in blocks[1]
     assert writer.consume_target_stream() == ""
+
+
+def test_yield_stream_bytes(byte_results):
+    writer = streaming.initialize_stream(byte_results, BytesWriter)
+    blocks = list(streaming.yield_stream(byte_results, writer))
+    assert b'\x00\x01\x00\x02' in blocks[0] # beginning of block
+    assert b'\x0b\x64\x0b\x65' in blocks[0] # end of block
+    assert b'\x20\x01\x20\x02' in blocks[1] # beginning of block
+    assert b'\x23\x26\x23\x27' in blocks[1] # end of block
+    assert writer.consume_target_stream() == b''


### PR DESCRIPTION
As a user of Nerium we sometimes see corporate csv payloads that are quite large and this can cause resource issues in our Nerium service.  This PR seeks to lessen that issue by providing a `csv.gz` format option that returns an `application/gzip` stream to the caller.

This PR (see second commit) also includes some refactoring of the Writer classes to better encapsulates the responsibility of managing the target stream and alleviate the need to pass the writer and stream together as separate method arguments
in several places.

Tests have been added and updated.